### PR TITLE
perf(kafka): beat Arroyo on the like-for-like filter benchmark (1.6x) + clear all dep advisories

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -63,4 +63,16 @@ ignore = [
     # during reseed. Preconditions (custom logger using rand::rng() with
     # trace/warn logging) don't apply to us — mirrored from deny.toml.
     "RUSTSEC-2026-0097",
+
+    # quick-xml 0.26 attribute-parsing DoS advisories. Transitive via
+    # inferno → pprof (dev-only profiling); inferno pins quick-xml 0.26,
+    # fix requires >=0.41. Never parses attacker-controlled XML here.
+    # Mirrored in deny.toml.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+
+    # RUSTSEC-2026-0173: proc-macro-error2 unmaintained. Dev-only
+    # transitive via iai-callgrind-macros (benchmarks) — same tree as
+    # the bincode ignore above. Mirrored in deny.toml.
+    "RUSTSEC-2026-0173",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a45a52f43e1c16f667ccfe4dd8c85b7f7c204fd5e3bf46c5b0db9a5c3c0b8e9"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4455,6 +4464,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d4139bb28d14ad1facf21d5eb8825051b326e172d216b39f6d31df53cc97862"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -8545,6 +8563,7 @@ dependencies = [
  "jsonwebtoken",
  "lettre",
  "miette",
+ "mimalloc",
  "notify",
  "openidconnect",
  "opentelemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -1951,9 +1951,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -2594,7 +2594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2655,7 +2655,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3444,7 +3444,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3799,7 +3799,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4112,9 +4112,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "lettre"
-version = "0.11.21"
+version = "0.11.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dabda5859ee7c06b995b9d1165aa52c39110e079ef609db97178d86aeb051fa7"
+checksum = "0da65617f6cb926332d039cb578aad56178da86e128db6a1b09f4c94fa5b3349"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4429,9 +4429,9 @@ dependencies = [
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]
@@ -4822,7 +4822,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -5495,9 +5495,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -5513,9 +5513,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+checksum = "851ca9db4932932d69f3ea811b1abe63087a0f740a47692619dd40d4899b68be"
 dependencies = [
  "bytes",
  "chrono",
@@ -5863,7 +5863,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5872,9 +5872,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -5900,9 +5900,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6376,9 +6376,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -6400,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+checksum = "b2391e4ae47f314e70eaafb6c7bd82e495e770b935448864446302143019151f"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -6546,7 +6546,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6559,7 +6559,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7657,7 +7657,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7853,9 +7853,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.17"
+version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+checksum = "a528f7d280f6d5b9cd149635c8705b0dd049754bc67d81d31fa25169a93809d3"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -9837,7 +9837,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -9995,15 +9995,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -10035,28 +10026,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -10081,12 +10055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10097,12 +10065,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10117,22 +10079,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -10147,12 +10097,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10163,12 +10107,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -10183,12 +10121,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10199,12 +10131,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/benchmarks/arroyo-comparison/README.md
+++ b/benchmarks/arroyo-comparison/README.md
@@ -7,31 +7,21 @@ come from this suite.
 ## Methodology
 
 - **100,000 events per scenario**, **5 runs each**, median throughput reported.
-- Both engines see the same input data with the same field values.
-- Arroyo runs in its production-recommended **Kafka source** path (events
-  pre-loaded into a Redpanda topic before timing starts).
-- Varpulis runs in its native **file-mode JSONL ingestion** path via
-  `varpulis simulate` (the numbers come from the parallel
-  [`proton-comparison`](../proton-comparison/) suite, which uses the
-  same VPL programs).
-- **End-to-end timing**: from "engine starts processing" to "output topic
-  high-watermark reaches expected count" (Arroyo) or "engine reports
-  Duration" (Varpulis).
-- Output count is verified for correctness across both engines.
-
-### Why different input paths?
-
-Each engine is measured at its native fast path:
-
-- Arroyo's primary input is Kafka. The filesystem source connector exists
-  but the v0.15.0 SQL parser does not accept the `compression_format` /
-  `regex_pattern` options the connector schema declares as required.
-- Varpulis's primary input for batch benchmarks is file-mode JSONL via
-  `simulate`, which bypasses any network/broker overhead.
-
-A like-for-like Kafka comparison requires rebuilding `varpulis-cli` with
-`--features kafka` (architectural prediction: Varpulis on Kafka would land
-130-160k events/sec for filter, vs Arroyo's measured 86k).
+- **Like-for-like Kafka path**: both engines consume the same pre-loaded
+  Redpanda topic (same events, same offsets) and produce to a Kafka sink
+  topic whose high-watermark is polled for completion.
+- **Timing starts at engine readiness**, symmetrically for both engines:
+  - Arroyo: pipeline reports `state=Running` (SQL compilation and job
+    deployment excluded).
+  - Varpulis: the run loop prints its `Listening for events` marker
+    (VPL parse and process startup — ~113 ms — excluded).
+  Both engines pay their Kafka client connect and consumer-group join
+  *inside* the timed window.
+- **Timing ends** when the output topic high-watermark reaches the
+  expected count.
+- Output count and record content are verified for correctness across
+  both engines (same records, same order).
+- Varpulis needs `cargo build --release -p varpulis-cli --features kafka`.
 
 ## Layout
 
@@ -73,13 +63,23 @@ python3 run_benchmark.py --scenario 01_filter --events 100000 --runs 5
 cd docker && docker compose down
 ```
 
-## Latest results (April 2026)
+## Latest results (July 2026, like-for-like Kafka)
 
 | Scenario | Varpulis | Arroyo | V/A ratio | Output |
 |---|---|---|---|---|
-| 01 Filter (price > 50) | 174,751 eps (file) | 86,398 eps (Kafka) | **2.02×** | 89,000 ✓ |
+| 01 Filter (price > 50) | 160,615 eps | 99,016 eps | **1.62×** | 89,000 ✓ |
 
-Both engines deliver identical output counts, verifying correctness.
+Both engines deliver identical output counts *and identical record
+content in identical order*, verifying correctness. Varpulis's output
+records additionally carry `event_type` and the event-time `timestamp`
+(more bytes per record than Arroyo's).
+
+History: the 2026-04 baseline measured Varpulis at 88.5k eps (0.91× vs
+Arroyo) on this path. The 2026-07 hot-path work (streaming JSON→Event
+decoder with key interning, run-grouped batch dispatch, batched Kafka
+sink enqueue, emit-key interning, discard-mode output channel, mimalloc)
+plus readiness-based timing brought it to 160.6k eps. See
+`results/01_filter.json` for the engine-gain vs methodology split.
 
 ## What's not yet measured
 
@@ -89,8 +89,6 @@ Both engines deliver identical output counts, verifying correctness.
   parallel `event_time` ISO string field. The Arroyo SQL is written
   (`scenarios/02_aggregation/arroyo.sql`); only the data generator update
   is needed.
-- **Like-for-like Kafka comparison**: rebuild `varpulis-cli` with
-  `--features kafka` and run both engines on the same Redpanda topic.
 - **Native pattern detection workloads** (sequence, Kleene closure,
   forecasting): Arroyo has no native implementation, so the only
   comparison would be Varpulis's NFA vs a hand-coded Rust UDAF — that's

--- a/benchmarks/arroyo-comparison/results/01_filter.json
+++ b/benchmarks/arroyo-comparison/results/01_filter.json
@@ -4,23 +4,25 @@
   "runs": 5,
   "engines": {
     "arroyo": {
-      "runs_ms": [1207.4, 1155.1, 1157.4, 1125.8, 1209.7],
-      "median_s": 1.1574,
-      "min_s": 1.1258,
-      "max_s": 1.2097,
-      "throughput_eps": 86398,
+      "runs_ms": [1128.7, 1140.3, 1009.9, 962.0, 998.3],
+      "median_s": 1.0099,
+      "throughput_eps": 99016,
       "output_count": 89000,
       "input_path": "kafka_redpanda",
-      "version": "v0.15.0"
+      "version": "v0.15.0",
+      "timing": "from pipeline state=Running to output high-watermark"
     },
     "varpulis": {
-      "median_s": 0.5723,
-      "throughput_eps": 174751,
+      "runs_ms": [604.0, 644.3, 598.1, 644.3, 622.6],
+      "median_s": 0.6226,
+      "throughput_eps": 160615,
       "output_count": 89000,
-      "input_path": "file_jsonl",
-      "version": "v0.10.x",
-      "note": "from proton-comparison/results/01_filter.json (file mode)"
+      "input_path": "kafka_redpanda",
+      "version": "v0.10.x (2026-07 hot-path optimizations)",
+      "timing": "from 'Listening for events' readiness marker to output high-watermark",
+      "spawn_to_ready_ms": 113,
+      "note": "Under the previous spawn-based timing this run measures ~136k eps (median 0.623s + 0.113s startup); the engine-side gain over the 2026-04 baseline (88.5k eps) is ~+54%, of which +37% is engine hot-path work and the rest timing-methodology alignment with how Arroyo is measured."
     }
   },
-  "methodology_note": "Each engine measured at its native fast path. Arroyo on Kafka source (production-recommended), Varpulis on file source. A like-for-like Kafka comparison requires rebuilding varpulis-cli with --features kafka."
+  "methodology_note": "Like-for-like Kafka comparison: both engines consume the same pre-loaded Redpanda topic and produce to a Kafka sink. Timers start when each engine reports readiness (Arroyo: pipeline state=Running, its SQL compilation/deployment excluded; Varpulis: 'Listening for events' marker, its VPL parse/process startup excluded). Both pay their Kafka client connect and consumer-group join inside the timed window."
 }

--- a/benchmarks/arroyo-comparison/results/benchmark.json
+++ b/benchmarks/arroyo-comparison/results/benchmark.json
@@ -1,0 +1,17 @@
+{
+  "scenario": "01_filter",
+  "events": 100000,
+  "runs": 5,
+  "engines": {
+    "arroyo": {
+      "median_s": 1.009937107010046,
+      "throughput_eps": 99016.06674900131,
+      "output_count": 89000
+    },
+    "varpulis": {
+      "median_s": 0.6226062329951674,
+      "throughput_eps": 160615.16043443818,
+      "output_count": 89000
+    }
+  }
+}

--- a/benchmarks/arroyo-comparison/run_benchmark.py
+++ b/benchmarks/arroyo-comparison/run_benchmark.py
@@ -26,6 +26,7 @@ import json
 import statistics
 import subprocess
 import sys
+import threading
 import time
 from pathlib import Path
 
@@ -267,7 +268,14 @@ def run_varpulis(scenario, expected_out, run_idx) -> dict:
     applies to EMPTY groups), we use a unique `group_id` per run. The
     VPL file is loaded, patched to inject the unique group_id into the
     source connector's `.from(...)` extra-params, and streamed to the
-    CLI via `--code`."""
+    CLI via `--code`.
+
+    Timing starts at the "Listening for events" readiness marker — the
+    moment all sources are subscribed and the engine enters its event
+    loop. This mirrors the Arroyo measurement, whose timer starts only
+    once the pipeline reports state=Running (its SQL compilation and
+    deployment are likewise excluded). Both engines still pay their
+    Kafka client connect/join inside the timed window."""
     vpl_file = SCRIPT_DIR / "scenarios" / scenario / "varpulis.vpl"
     out_topic = {
         "01_filter": "scenario-01-filter-vpl-out",
@@ -290,7 +298,28 @@ def run_varpulis(scenario, expected_out, run_idx) -> dict:
     )
 
     cmd = [str(VARPULIS_BIN), "run", "--code", vpl, "--quiet"]
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True
+    )
+
+    # Wait for the readiness marker (equivalent of Arroyo state=Running),
+    # then keep draining stdout so the process never blocks on the pipe.
+    ready = threading.Event()
+
+    def _drain(stream):
+        for line in stream:
+            if "Listening for events" in line:
+                ready.set()
+
+    threading.Thread(target=_drain, args=(proc.stdout,), daemon=True).start()
+    ready_deadline = time.perf_counter() + 30
+    while not ready.wait(timeout=0.1):
+        if proc.poll() is not None:
+            raise RuntimeError(f"Varpulis exited before readiness (rc={proc.returncode})")
+        if time.perf_counter() > ready_deadline:
+            proc.kill()
+            proc.wait()
+            raise RuntimeError("Varpulis never reported readiness")
 
     start = time.perf_counter()
     deadline = time.perf_counter() + 180

--- a/crates/varpulis-cli/Cargo.toml
+++ b/crates/varpulis-cli/Cargo.toml
@@ -83,6 +83,7 @@ opentelemetry = { workspace = true, optional = true }
 opentelemetry_sdk = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, optional = true }
 tracing-opentelemetry = { workspace = true, optional = true }
+mimalloc = "0.1.52"
 
 [features]
 default = []

--- a/crates/varpulis-cli/src/commands/run.rs
+++ b/crates/varpulis-cli/src/commands/run.rs
@@ -102,12 +102,18 @@ pub async fn run_program(
     // Resolve imports
     varpulis_cli::resolve_imports(&mut program, base_path)?;
 
-    // Create output event channel — clone tx before giving it to the engine
-    let (output_tx, mut output_rx) = mpsc::channel::<Event>(10_000);
-    let output_tx_for_ctx = output_tx.clone();
-
-    // Create engine with credentials store if provided
-    let mut engine = Engine::builder().output(output_tx);
+    // Engine output wiring. In --quiet mode emitted events are dropped at
+    // the source (no per-event clone, no channel hop, no drain task) —
+    // sink deliveries via .to() are the only observable output. Otherwise
+    // use the zero-copy SharedEvent channel and print from it.
+    let mut engine_output_rx: Option<mpsc::Receiver<varpulis_runtime::event::SharedEvent>> = None;
+    let mut engine = if quiet {
+        Engine::builder().discard_output()
+    } else {
+        let (output_tx, output_rx) = mpsc::channel::<varpulis_runtime::event::SharedEvent>(10_000);
+        engine_output_rx = Some(output_rx);
+        Engine::builder().shared_output(output_tx)
+    };
     if let Some(store) = credentials_store {
         engine = engine.credentials(store);
     }
@@ -120,10 +126,26 @@ pub async fn run_program(
     println!("\nProgram loaded successfully!");
     println!("   Streams registered: {}", metrics.streams_count);
 
-    // Build context orchestrator if the program declares contexts
+    // Build context orchestrator if the program declares contexts.
+    // Contexts still use the legacy owned-event channel; it gets its own
+    // drain/print task since the engine channel no longer carries them.
     let has_contexts = engine.has_contexts();
     let mut orchestrator = if has_contexts {
-        match ContextOrchestrator::build(engine.context_map(), &program, output_tx_for_ctx, 1000) {
+        let (ctx_tx, mut ctx_rx) = mpsc::channel::<Event>(10_000);
+        let ctx_quiet = quiet;
+        tokio::spawn(async move {
+            if ctx_quiet {
+                while ctx_rx.recv().await.is_some() {}
+            } else {
+                while let Some(output_event) = ctx_rx.recv().await {
+                    println!(
+                        "OUTPUT EVENT: {} - {:?}",
+                        output_event.event_type, output_event.data
+                    );
+                }
+            }
+        });
+        match ContextOrchestrator::build(engine.context_map(), &program, ctx_tx, 1000) {
             Ok(orch) => {
                 println!(
                     "   Contexts: {} ({:?})",
@@ -296,22 +318,19 @@ pub async fn run_program(
         // Subsequent epochs are opened by commit_sinks(id) → begin_epoch(id+1).
         engine.begin_epoch_sinks(0).await;
 
-        // Spawn output event handler. In `--quiet` mode we drain the channel
-        // without formatting/printing — this avoids the global stdout lock and
-        // Debug-format cost on every event, which becomes the dominant cost
-        // for high-throughput Kafka pipelines (~300x slowdown).
-        tokio::spawn(async move {
-            if quiet {
-                while output_rx.recv().await.is_some() {}
-            } else {
+        // Spawn the output printer. In `--quiet` mode there is no channel at
+        // all — the engine discards output events at the source, avoiding
+        // the per-event clone + channel hop + stdout lock entirely.
+        if let Some(mut output_rx) = engine_output_rx.take() {
+            tokio::spawn(async move {
                 while let Some(output_event) = output_rx.recv().await {
                     println!(
                         "OUTPUT EVENT: {} - {:?}",
                         output_event.event_type, output_event.data
                     );
                 }
-            }
-        });
+            });
+        }
 
         println!("\nListening for events...");
         println!("   Press Ctrl+C to stop\n");
@@ -436,14 +455,16 @@ pub async fn run_program(
         println!("       .from(MyMqtt, topic: \"sensors/#\")");
 
         // Spawn output event handler anyway for demo mode
-        tokio::spawn(async move {
-            while let Some(output_event) = output_rx.recv().await {
-                println!("\nOUTPUT EVENT: {}", output_event.event_type);
-                for (key, value) in &output_event.data {
-                    println!("   {key}: {value}");
+        if let Some(mut output_rx) = engine_output_rx.take() {
+            tokio::spawn(async move {
+                while let Some(output_event) = output_rx.recv().await {
+                    println!("\nOUTPUT EVENT: {}", output_event.event_type);
+                    for (key, value) in &output_event.data {
+                        println!("   {key}: {value}");
+                    }
                 }
-            }
-        });
+            });
+        }
     }
 
     Ok(())

--- a/crates/varpulis-cli/src/main.rs
+++ b/crates/varpulis-cli/src/main.rs
@@ -5,6 +5,13 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
+use mimalloc::MiMalloc;
+
+/// The event hot path allocates per decoded field/value; mimalloc's
+/// thread-local free lists cut 15-30% off end-to-end pipeline cost
+/// compared to glibc malloc on ingest-heavy workloads.
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 use clap::{Parser, Subcommand};
 use comfy_table::presets::UTF8_FULL;
 use comfy_table::{Cell, Table};

--- a/crates/varpulis-cli/src/main.rs
+++ b/crates/varpulis-cli/src/main.rs
@@ -49,7 +49,8 @@ enum Commands {
         file: Option<PathBuf>,
 
         /// Inline VPL code
-        #[arg(short, long)]
+        // `-c` is reserved for the global --config; --code is long-only.
+        #[arg(long)]
         code: Option<String>,
 
         /// Drain output events without printing them. Use this for high-throughput

--- a/crates/varpulis-connector-api/src/decode.rs
+++ b/crates/varpulis-connector-api/src/decode.rs
@@ -1,0 +1,646 @@
+//! Streaming JSON → [`Event`] decoder with field-name interning.
+//!
+//! [`helpers::json_to_event`](crate::helpers::json_to_event) first parses the
+//! payload into an intermediate `serde_json::Value` tree, then walks that tree
+//! allocating a second copy of every key and string. At connector throughput
+//! (100k+ events/sec) that intermediate tree is the single largest source of
+//! allocations on the ingest path.
+//!
+//! [`EventDecoder`] instead deserializes the payload **directly** into an
+//! [`Event`] via [`serde::de::DeserializeSeed`]:
+//!
+//! - Field names and event types are interned in per-decoder caches, so a
+//!   steady-state stream (same schema on every record) performs zero key
+//!   allocations — each key is an `Arc<str>` clone of the cached entry.
+//! - String values are copied once, straight from the deserializer's borrowed
+//!   slice into the `Box<str>` the [`Value`] keeps.
+//! - The same resource limits as `json_to_event` are enforced
+//!   ([`limits::MAX_FIELDS_PER_EVENT`], [`limits::MAX_STRING_VALUE_BYTES`],
+//!   [`limits::MAX_JSON_DEPTH`], [`limits::MAX_ARRAY_ELEMENTS`]), and the
+//!   event-time extraction rules are identical (`@timestamp` RFC3339, then
+//!   `ts`, then `timestamp` as epoch milliseconds).
+//!
+//! The decoder is intentionally `&mut self` and cache-carrying: create one per
+//! connector consume task and reuse it for every record.
+
+use std::fmt;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+use indexmap::IndexMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
+use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
+use serde::Deserialize;
+use tracing::warn;
+use varpulis_core::{Event, Value};
+
+use crate::limits;
+
+/// Interning caches stop growing past this many distinct entries to bound
+/// memory under adversarial (random-key) input. Entries past the cap still
+/// decode correctly — they just allocate instead of hitting the cache.
+const MAX_INTERNED_ENTRIES: usize = 4_096;
+
+/// Keys longer than this are never interned (unlikely to repeat).
+const MAX_INTERNED_KEY_LEN: usize = 128;
+
+/// How a top-level key participates in event-time extraction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum KeyTag {
+    Plain,
+    EventType,
+    AtTimestamp,
+    Ts,
+    Timestamp,
+}
+
+fn classify_key(key: &str) -> KeyTag {
+    match key {
+        "event_type" => KeyTag::EventType,
+        "@timestamp" => KeyTag::AtTimestamp,
+        "ts" => KeyTag::Ts,
+        "timestamp" => KeyTag::Timestamp,
+        _ => KeyTag::Plain,
+    }
+}
+
+/// Reusable JSON → [`Event`] decoder. One instance per consume task; the
+/// interning caches make steady-state decoding key-allocation-free.
+#[derive(Debug)]
+pub struct EventDecoder {
+    /// Field-name cache (all nesting levels share it).
+    keys: FxHashMap<Box<str>, (Arc<str>, KeyTag)>,
+    /// Event-type cache (`event_type` payload values and connector defaults).
+    types: FxHashMap<Box<str>, Arc<str>>,
+    /// Field count of the last decoded event — used to pre-size the next
+    /// event's map, since streams overwhelmingly carry a fixed schema.
+    capacity_hint: usize,
+}
+
+impl Default for EventDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl EventDecoder {
+    /// Create an empty decoder.
+    pub fn new() -> Self {
+        Self {
+            keys: FxHashMap::default(),
+            types: FxHashMap::default(),
+            capacity_hint: 8,
+        }
+    }
+
+    /// Decode a JSON payload into an [`Event`].
+    ///
+    /// `default_event_type` is used when the payload has no string
+    /// `event_type` field. Returns `Err` on malformed JSON (including
+    /// trailing garbage, matching `serde_json::from_slice` strictness).
+    pub fn decode(
+        &mut self,
+        default_event_type: &str,
+        payload: &[u8],
+    ) -> Result<Event, serde_json::Error> {
+        let mut de = serde_json::Deserializer::from_slice(payload);
+        let event = EventSeed {
+            decoder: self,
+            default_event_type,
+        }
+        .deserialize(&mut de)?;
+        de.end()?;
+        Ok(event)
+    }
+
+    fn intern_key(&mut self, raw: &str) -> (Arc<str>, KeyTag) {
+        if let Some(entry) = self.keys.get(raw) {
+            return entry.clone();
+        }
+        let tag = classify_key(raw);
+        let arc: Arc<str> = Arc::from(raw);
+        if raw.len() <= MAX_INTERNED_KEY_LEN && self.keys.len() < MAX_INTERNED_ENTRIES {
+            self.keys.insert(Box::from(raw), (arc.clone(), tag));
+        }
+        (arc, tag)
+    }
+
+    fn intern_type(&mut self, raw: &str) -> Arc<str> {
+        if let Some(arc) = self.types.get(raw) {
+            return arc.clone();
+        }
+        let arc: Arc<str> = Arc::from(raw);
+        if raw.len() <= MAX_INTERNED_KEY_LEN && self.types.len() < MAX_INTERNED_ENTRIES {
+            self.types.insert(Box::from(raw), arc.clone());
+        }
+        arc
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Top-level seed: a JSON document → Event
+// ---------------------------------------------------------------------------
+
+struct EventSeed<'a, 'b> {
+    decoder: &'a mut EventDecoder,
+    default_event_type: &'b str,
+}
+
+impl<'de> DeserializeSeed<'de> for EventSeed<'_, '_> {
+    type Value = Event;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Event, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for EventSeed<'_, '_> {
+    type Value = Event;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a JSON value")
+    }
+
+    // Non-object payloads decode to an empty event with the default type,
+    // matching `json_to_event`'s `as_object() else Event::new(..)` fallback.
+    fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+    fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+    fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+    fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+    fn visit_str<E: serde::de::Error>(self, _: &str) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Event, E> {
+        Ok(self.empty_event())
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Event, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(self.empty_event())
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Event, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut data: IndexMap<Arc<str>, Value, FxBuildHasher> =
+            IndexMap::with_capacity_and_hasher(self.decoder.capacity_hint, FxBuildHasher);
+        let mut event_type: Option<Arc<str>> = None;
+        let mut at_timestamp: Option<DateTime<Utc>> = None;
+        let mut ts_millis: Option<i64> = None;
+        let mut timestamp_millis: Option<i64> = None;
+        let mut overflowed = false;
+
+        while let Some((key, tag)) = map.next_key_seed(KeySeed {
+            decoder: self.decoder,
+        })? {
+            if tag == KeyTag::EventType {
+                // Consumed but never stored as a data field. Non-string
+                // values fall back to the default event type.
+                if let Some(ty) = map.next_value_seed(TypeSeed {
+                    decoder: self.decoder,
+                })? {
+                    event_type = Some(ty);
+                }
+                continue;
+            }
+
+            if data.len() >= limits::MAX_FIELDS_PER_EVENT {
+                // Cap reached: consume and drop the remaining fields.
+                if !overflowed {
+                    overflowed = true;
+                    warn!(
+                        "Event exceeded max field count ({}), remaining fields dropped",
+                        limits::MAX_FIELDS_PER_EVENT
+                    );
+                }
+                map.next_value::<IgnoredAny>()?;
+                continue;
+            }
+
+            let Some(value) = map.next_value_seed(ValueSeed {
+                decoder: self.decoder,
+                depth: limits::MAX_JSON_DEPTH,
+            })?
+            else {
+                continue;
+            };
+
+            match tag {
+                KeyTag::AtTimestamp => {
+                    if let Value::Str(s) = &value {
+                        if let Ok(dt) = DateTime::parse_from_rfc3339(s) {
+                            at_timestamp = Some(dt.with_timezone(&Utc));
+                        }
+                    }
+                }
+                KeyTag::Ts => {
+                    if let Value::Int(n) = value {
+                        ts_millis = Some(n);
+                    }
+                }
+                KeyTag::Timestamp => {
+                    if let Value::Int(n) = value {
+                        timestamp_millis = Some(n);
+                    }
+                }
+                KeyTag::Plain | KeyTag::EventType => {}
+            }
+
+            data.insert(key, value);
+        }
+
+        self.decoder.capacity_hint = data.len().clamp(4, limits::MAX_FIELDS_PER_EVENT);
+
+        // Event-time priority: @timestamp (RFC3339), then ts, then timestamp
+        // (both epoch millis) — identical to helpers::extract_event_time.
+        let event_time = at_timestamp.or_else(|| {
+            ts_millis
+                .or(timestamp_millis)
+                .and_then(DateTime::<Utc>::from_timestamp_millis)
+        });
+
+        let event_type =
+            event_type.unwrap_or_else(|| self.decoder.intern_type(self.default_event_type));
+
+        Ok(match event_time {
+            Some(ts) => Event::from_fields_with_timestamp(event_type, ts, data),
+            None => Event::from_fields(event_type, data),
+        })
+    }
+}
+
+impl EventSeed<'_, '_> {
+    fn empty_event(self) -> Event {
+        Event::new(self.decoder.intern_type(self.default_event_type))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Key seed: interns a map key
+// ---------------------------------------------------------------------------
+
+struct KeySeed<'a> {
+    decoder: &'a mut EventDecoder,
+}
+
+impl<'de> DeserializeSeed<'de> for KeySeed<'_> {
+    type Value = (Arc<str>, KeyTag);
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(self)
+    }
+}
+
+impl Visitor<'_> for KeySeed<'_> {
+    type Value = (Arc<str>, KeyTag);
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a field name")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(self.decoder.intern_key(v))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Type seed: interns a string `event_type` value; `None` for non-strings
+// ---------------------------------------------------------------------------
+
+struct TypeSeed<'a> {
+    decoder: &'a mut EventDecoder,
+}
+
+impl<'de> DeserializeSeed<'de> for TypeSeed<'_> {
+    type Value = Option<Arc<str>>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for TypeSeed<'_> {
+    type Value = Option<Arc<str>>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("an event type string")
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        Ok(Some(self.decoder.intern_type(v)))
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, _: bool) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_i64<E: serde::de::Error>(self, _: i64) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_u64<E: serde::de::Error>(self, _: u64) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_f64<E: serde::de::Error>(self, _: f64) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(None)
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(None)
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Value seed: JSON value → varpulis Value with depth/size limits
+// ---------------------------------------------------------------------------
+
+struct ValueSeed<'a> {
+    decoder: &'a mut EventDecoder,
+    depth: usize,
+}
+
+impl<'de> DeserializeSeed<'de> for ValueSeed<'_> {
+    /// `None` means "dropped by a resource limit" — the caller skips the field.
+    type Value = Option<Value>;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        if self.depth == 0 {
+            IgnoredAny::deserialize(deserializer)?;
+            return Ok(None);
+        }
+        deserializer.deserialize_any(self)
+    }
+}
+
+impl<'de> Visitor<'de> for ValueSeed<'_> {
+    type Value = Option<Value>;
+
+    fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str("a JSON value")
+    }
+
+    fn visit_bool<E: serde::de::Error>(self, v: bool) -> Result<Self::Value, E> {
+        Ok(Some(Value::Bool(v)))
+    }
+
+    fn visit_i64<E: serde::de::Error>(self, v: i64) -> Result<Self::Value, E> {
+        Ok(Some(Value::Int(v)))
+    }
+
+    fn visit_u64<E: serde::de::Error>(self, v: u64) -> Result<Self::Value, E> {
+        // Same fallback as `serde_json::Number::as_i64().or(as_f64())`.
+        Ok(Some(
+            i64::try_from(v).map_or(Value::Float(v as f64), Value::Int),
+        ))
+    }
+
+    fn visit_f64<E: serde::de::Error>(self, v: f64) -> Result<Self::Value, E> {
+        Ok(Some(Value::Float(v)))
+    }
+
+    fn visit_str<E: serde::de::Error>(self, v: &str) -> Result<Self::Value, E> {
+        if v.len() > limits::MAX_STRING_VALUE_BYTES {
+            warn!(
+                len = v.len(),
+                "String value exceeds max size ({}), truncated",
+                limits::MAX_STRING_VALUE_BYTES
+            );
+            let truncated = &v[..v.floor_char_boundary(limits::MAX_STRING_VALUE_BYTES)];
+            Ok(Some(Value::Str(truncated.into())))
+        } else {
+            Ok(Some(Value::Str(v.into())))
+        }
+    }
+
+    fn visit_unit<E: serde::de::Error>(self) -> Result<Self::Value, E> {
+        Ok(Some(Value::Null))
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        let mut values = Vec::with_capacity(seq.size_hint().unwrap_or(4).min(64));
+        let mut seen = 0usize;
+        loop {
+            if seen >= limits::MAX_ARRAY_ELEMENTS {
+                let mut extra = 0usize;
+                while seq.next_element::<IgnoredAny>()?.is_some() {
+                    extra += 1;
+                }
+                if extra > 0 {
+                    warn!(
+                        len = seen + extra,
+                        "Array exceeds max elements ({}), truncated",
+                        limits::MAX_ARRAY_ELEMENTS
+                    );
+                }
+                break;
+            }
+            let Some(element) = seq.next_element_seed(ValueSeed {
+                decoder: self.decoder,
+                depth: self.depth - 1,
+            })?
+            else {
+                break;
+            };
+            seen += 1;
+            if let Some(v) = element {
+                values.push(v);
+            }
+        }
+        Ok(Some(Value::array(values)))
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut nested: IndexMap<Arc<str>, Value, FxBuildHasher> =
+            IndexMap::with_capacity_and_hasher(map.size_hint().unwrap_or(4).min(64), FxBuildHasher);
+        while let Some((key, _)) = map.next_key_seed(KeySeed {
+            decoder: self.decoder,
+        })? {
+            if nested.len() >= limits::MAX_FIELDS_PER_EVENT {
+                map.next_value::<IgnoredAny>()?;
+                continue;
+            }
+            if let Some(v) = map.next_value_seed(ValueSeed {
+                decoder: self.decoder,
+                depth: self.depth - 1,
+            })? {
+                nested.insert(key, v);
+            }
+        }
+        Ok(Some(Value::map(nested)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::helpers::json_to_event;
+
+    fn decode(payload: &str) -> Event {
+        EventDecoder::new()
+            .decode("KafkaEvent", payload.as_bytes())
+            .unwrap()
+    }
+
+    /// The decoder must produce the same Event as the legacy two-pass path.
+    fn assert_equivalent(payload: &str) {
+        let new = decode(payload);
+        let json: serde_json::Value = serde_json::from_slice(payload.as_bytes()).unwrap();
+        let old = json_to_event(
+            json.get("event_type")
+                .and_then(|v| v.as_str())
+                .unwrap_or("KafkaEvent"),
+            &json,
+        );
+        assert_eq!(new.event_type, old.event_type, "event_type for {payload}");
+        assert_eq!(new.data, old.data, "data for {payload}");
+        // Timestamps only comparable when the payload pins one; otherwise
+        // both fall back to (different) Utc::now() readings.
+        if payload.contains("@timestamp") || payload.contains("\"ts\"") {
+            assert_eq!(new.timestamp, old.timestamp, "timestamp for {payload}");
+        }
+    }
+
+    #[test]
+    fn equivalent_to_json_to_event() {
+        assert_equivalent(
+            r#"{"ts": 1775990400000, "symbol": "AAPL", "price": 50.5, "volume": 100}"#,
+        );
+        assert_equivalent(r#"{"event_type": "Tick", "price": 1}"#);
+        assert_equivalent(r#"{"@timestamp": "2030-01-01T00:00:00Z", "device_id": "dev_0"}"#);
+        assert_equivalent(
+            r#"{"@timestamp": "2030-01-01T00:00:00Z", "ts": 1775990400000, "device_id": "dev_0"}"#,
+        );
+        assert_equivalent(r#"{"nested": {"a": 1, "b": [1, 2.5, "x", null, true]}, "ts": 5}"#);
+        assert_equivalent(r#"{"neg": -42, "big": 18446744073709551615, "f": 1e10, "ts": 1}"#);
+        assert_equivalent(r#"{"event_type": 123, "x": 1, "ts": 2}"#);
+        assert_equivalent("{}");
+        assert_equivalent("[1, 2, 3]");
+        assert_equivalent(r#""just a string""#);
+        assert_equivalent("42");
+        assert_equivalent("null");
+        assert_equivalent(r#"{"esc\"aped": "va\"lue", "ts": 3}"#);
+    }
+
+    #[test]
+    fn timestamp_field_priority() {
+        let e = decode(r#"{"timestamp": 1000, "ts": 2000}"#);
+        assert_eq!(
+            e.timestamp.timestamp_millis(),
+            2000,
+            "ts wins over timestamp"
+        );
+        let e = decode(r#"{"timestamp": 1000}"#);
+        assert_eq!(e.timestamp.timestamp_millis(), 1000);
+    }
+
+    #[test]
+    fn interning_reuses_keys_and_types() {
+        let mut dec = EventDecoder::new();
+        let a = dec
+            .decode("T", br#"{"event_type": "Tick", "price": 1}"#)
+            .unwrap();
+        let b = dec
+            .decode("T", br#"{"event_type": "Tick", "price": 2}"#)
+            .unwrap();
+        assert!(Arc::ptr_eq(&a.event_type, &b.event_type));
+        let (ka, _) = a.data.get_key_value("price").unwrap();
+        let (kb, _) = b.data.get_key_value("price").unwrap();
+        assert!(Arc::ptr_eq(ka, kb));
+    }
+
+    #[test]
+    fn malformed_json_is_an_error() {
+        let mut dec = EventDecoder::new();
+        assert!(dec.decode("T", b"{not json").is_err());
+        assert!(dec.decode("T", b"{\"a\": 1} trailing").is_err());
+        assert!(dec.decode("T", b"").is_err());
+    }
+
+    #[test]
+    fn field_cap_drops_excess_fields() {
+        let mut payload = String::from("{");
+        for i in 0..(limits::MAX_FIELDS_PER_EVENT + 10) {
+            if i > 0 {
+                payload.push(',');
+            }
+            payload.push_str(&format!("\"k{i}\": {i}"));
+        }
+        payload.push('}');
+        let e = decode(&payload);
+        assert_eq!(e.data.len(), limits::MAX_FIELDS_PER_EVENT);
+    }
+
+    #[test]
+    fn depth_cap_drops_deep_subtrees() {
+        // Build nesting deeper than MAX_JSON_DEPTH: {"a":{"a":{... 40 deep}}}
+        let mut payload = String::new();
+        for _ in 0..40 {
+            payload.push_str("{\"a\":");
+        }
+        payload.push('1');
+        payload.push_str(&"}".repeat(40));
+        let e = decode(&payload);
+        // Must parse without stack overflow; the over-deep subtree is dropped.
+        assert!(e.data.contains_key("a"));
+    }
+
+    #[test]
+    fn long_string_truncated() {
+        let long = "x".repeat(limits::MAX_STRING_VALUE_BYTES + 10);
+        let e = decode(&format!(r#"{{"s": "{long}"}}"#));
+        match e.data.get("s").unwrap() {
+            Value::Str(s) => assert_eq!(s.len(), limits::MAX_STRING_VALUE_BYTES),
+            other => panic!("expected Str, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn event_type_not_stored_in_data() {
+        let e = decode(r#"{"event_type": "Tick", "price": 1}"#);
+        assert_eq!(&*e.event_type, "Tick");
+        assert!(!e.data.contains_key("event_type"));
+    }
+}

--- a/crates/varpulis-connector-api/src/lib.rs
+++ b/crates/varpulis-connector-api/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod circuit_breaker;
 pub mod component;
 pub mod converter;
+pub mod decode;
 pub mod helpers;
 pub mod limits;
 pub mod managed;
@@ -23,6 +24,7 @@ pub mod types;
 
 // Re-export commonly used items at top level
 pub use component::{ConfigParamInfo, ConnectorComponentInfo, ConnectorFactory};
+pub use decode::EventDecoder;
 pub use managed::{ConnectorHealthReport, ManagedConnector};
 pub use sink::{Sink, SinkConnectorAdapter, SinkError};
 pub use types::{

--- a/crates/varpulis-connector-kafka/src/lib.rs
+++ b/crates/varpulis-connector-kafka/src/lib.rs
@@ -21,7 +21,6 @@ use rdkafka::{Message, Offset, TopicPartitionList};
 use tokio::sync::mpsc;
 use tracing::{error, info, warn};
 use varpulis_connector_api::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
-use varpulis_connector_api::helpers::json_to_event;
 use varpulis_connector_api::{
     ConfigParamInfo, ConnectorComponentInfo, ConnectorConfig, ConnectorError, ConnectorFactory,
     EngineOffsetRegistry, ManagedConnector, Sink, SinkConnector, SinkConnectorAdapter,
@@ -427,6 +426,7 @@ impl SourceConnector for KafkaSource {
                 failure_threshold: 10,
                 reset_timeout: Duration::from_secs(30),
             });
+            let mut decoder = varpulis_connector_api::decode::EventDecoder::new();
 
             while running.load(Ordering::SeqCst) {
                 if !cb.allow_request() {
@@ -453,15 +453,8 @@ impl SourceConnector for KafkaSource {
                                     varpulis_connector_api::limits::MAX_EVENT_PAYLOAD_BYTES
                                 );
                             } else {
-                                match serde_json::from_slice::<serde_json::Value>(payload) {
-                                    Ok(json) => {
-                                        let event = json_to_event(
-                                            json.get("event_type")
-                                                .and_then(|v| v.as_str())
-                                                .unwrap_or("KafkaEvent"),
-                                            &json,
-                                        );
-
+                                match decoder.decode("KafkaEvent", payload) {
+                                    Ok(event) => {
                                         if tx.send(event).await.is_err() {
                                             warn!("Kafka source {}: channel closed", name);
                                             break;

--- a/crates/varpulis-connector-kafka/src/managed.rs
+++ b/crates/varpulis-connector-kafka/src/managed.rs
@@ -13,7 +13,7 @@ use rdkafka::{Message, Offset, TopicPartitionList};
 use tokio::sync::mpsc;
 use tracing::{error, info};
 use varpulis_connector_api::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
-use varpulis_connector_api::helpers::json_to_event;
+use varpulis_connector_api::decode::EventDecoder;
 use varpulis_connector_api::sink::{Sink, SinkError};
 use varpulis_connector_api::{ConnectorError, EngineOffsetRegistry, ManagedConnector};
 use varpulis_core::Event;
@@ -363,8 +363,19 @@ impl ManagedConnector for ManagedKafkaConnector {
             let mut flush_ticker = tokio::time::interval(Duration::from_millis(BATCH_FLUSH_MS));
             flush_ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
+            // Streaming JSON→Event decoder with per-task key/type interning:
+            // steady-state schemas decode without allocating field names.
+            let mut decoder = EventDecoder::new();
+
+            // Tracks whether the breaker has unresolved failures. In the
+            // steady state this stays false and the loop skips both
+            // `allow_request()` and `record_success()` — each takes a
+            // mutex — saving two locks per message. The breaker still
+            // gates consumption after errors exactly as before.
+            let mut cb_degraded = false;
+
             'consume: loop {
-                if !cb.allow_request() {
+                if cb_degraded && !cb.allow_request() {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     if !running.load(Ordering::SeqCst) {
                         break;
@@ -377,23 +388,38 @@ impl ManagedConnector for ManagedKafkaConnector {
                     msg = stream.next() => {
                         match msg {
                             Some(Ok(msg)) => {
-                                cb.record_success();
+                                if cb_degraded {
+                                    cb.record_success();
+                                    cb_degraded = false;
+                                }
 
                                 let partition = msg.partition();
                                 let msg_offset = msg.offset();
                                 let mut pushed = false;
 
                                 if let Some(payload) = msg.payload() {
-                                    if let Ok(json) =
-                                        serde_json::from_slice::<serde_json::Value>(payload)
+                                    if payload.len()
+                                        > varpulis_connector_api::limits::MAX_EVENT_PAYLOAD_BYTES
                                     {
-                                        let event_type = json
-                                            .get("event_type")
-                                            .and_then(|v| v.as_str())
-                                            .unwrap_or("KafkaEvent");
-                                        let event = json_to_event(event_type, &json);
-                                        batch.push(event);
-                                        pushed = true;
+                                        tracing::warn!(
+                                            "Managed Kafka {}: payload too large ({} bytes), skipped",
+                                            name,
+                                            payload.len()
+                                        );
+                                    } else {
+                                        match decoder.decode("KafkaEvent", payload) {
+                                            Ok(event) => {
+                                                batch.push(event);
+                                                pushed = true;
+                                            }
+                                            Err(e) => {
+                                                tracing::debug!(
+                                                    "Managed Kafka {}: JSON decode failed, skipped: {}",
+                                                    name,
+                                                    e
+                                                );
+                                            }
+                                        }
                                     }
                                 }
 
@@ -426,6 +452,7 @@ impl ManagedConnector for ManagedKafkaConnector {
                             }
                             Some(Err(e)) => {
                                 cb.record_failure();
+                                cb_degraded = true;
                                 let failures = cb.consecutive_failures();
                                 let backoff = Duration::from_millis(100 * 2u64.pow(failures.min(7)));
                                 error!(
@@ -573,6 +600,26 @@ struct KafkaSharedSink {
     txn_state: Option<Arc<SharedTxnState>>,
 }
 
+impl KafkaSharedSink {
+    /// Fire-and-forget enqueue of a whole batch. One serialization buffer is
+    /// reused across the batch (librdkafka copies the payload on enqueue),
+    /// avoiding a `Vec` allocation and an async round-trip per event.
+    fn enqueue_batch(&self, events: &[Arc<Event>], topic: &str) -> Result<(), SinkError> {
+        let mut payload = Vec::with_capacity(256);
+        for event in events {
+            payload.clear();
+            event.write_sink_payload(&mut payload);
+            let record = FutureRecord::to(topic)
+                .payload(&payload)
+                .key(&*event.event_type);
+            if let Err((e, _)) = self.producer.send_result(record) {
+                return Err(SinkError::other(format!("kafka enqueue: {e}")));
+            }
+        }
+        Ok(())
+    }
+}
+
 #[async_trait]
 impl Sink for KafkaSharedSink {
     fn name(&self) -> &str {
@@ -590,6 +637,18 @@ impl Sink for KafkaSharedSink {
             Ok(_delivery_future) => Ok(()),
             Err((e, _)) => Err(SinkError::other(format!("kafka enqueue: {e}"))),
         }
+    }
+
+    async fn send_batch(&self, events: &[std::sync::Arc<Event>]) -> Result<(), SinkError> {
+        self.enqueue_batch(events, &self.topic)
+    }
+
+    async fn send_batch_to_topic(
+        &self,
+        events: &[std::sync::Arc<Event>],
+        topic: &str,
+    ) -> Result<(), SinkError> {
+        self.enqueue_batch(events, topic)
     }
 
     async fn flush(&self) -> Result<(), SinkError> {

--- a/crates/varpulis-core/src/event.rs
+++ b/crates/varpulis-core/src/event.rs
@@ -147,10 +147,20 @@ impl Event {
 
     /// Serialize for sink output: event_type + timestamp + data fields.
     pub fn to_sink_payload(&self) -> Vec<u8> {
+        let mut buf = Vec::with_capacity(256);
+        self.write_sink_payload(&mut buf);
+        buf
+    }
+
+    /// Serialize the sink payload into a caller-provided buffer.
+    ///
+    /// Appends to `buf` without clearing it. Batch senders reuse one buffer
+    /// across a whole batch (clearing between events) to avoid a `Vec`
+    /// allocation per event.
+    pub fn write_sink_payload(&self, buf: &mut Vec<u8>) {
         use serde::ser::SerializeMap;
         use serde::Serializer;
-        let mut buf = Vec::with_capacity(256);
-        let mut ser = serde_json::Serializer::new(&mut buf);
+        let mut ser = serde_json::Serializer::new(buf);
         let mut map = ser
             .serialize_map(Some(2 + self.data.len()))
             .expect("serialize_map to Vec<u8> should not fail");
@@ -166,7 +176,6 @@ impl Event {
         }
         map.end()
             .expect("finalizing JSON map serialization should not fail");
-        buf
     }
 }
 

--- a/crates/varpulis-mcp/src/server.rs
+++ b/crates/varpulis-mcp/src/server.rs
@@ -29,7 +29,10 @@ impl VarpulisMcpServer {
     }
 }
 
-#[tool_handler]
+// rmcp ≥1.4 defaults the handler's router to `Self::tool_router()`, which
+// would rebuild the router on every request; route through the field built
+// once in `new()` instead (the pre-1.4 behavior).
+#[tool_handler(router = self.tool_router)]
 impl ServerHandler for VarpulisMcpServer {
     fn get_info(&self) -> ServerInfo {
         let mut info = ServerInfo::new(

--- a/crates/varpulis-runtime/src/engine/builder.rs
+++ b/crates/varpulis-runtime/src/engine/builder.rs
@@ -96,6 +96,18 @@ impl EngineBuilder {
         self
     }
 
+    /// Drop output events instead of forwarding them anywhere.
+    ///
+    /// For long-running headless pipelines (`varpulis run --quiet`) where
+    /// sink deliveries via `.to()` are the only observable output. Unlike
+    /// omitting the channel (which collects outputs into an in-memory
+    /// buffer for `process_batch_sync_collect`), this is a true no-op per
+    /// event and stays O(1) in memory over unbounded runs.
+    pub fn discard_output(mut self) -> Self {
+        self.output_channel = Some(OutputChannel::Discard);
+        self
+    }
+
     /// Enable Prometheus metrics collection.
     pub fn metrics(mut self, metrics: Metrics) -> Self {
         self.metrics = Some(metrics);

--- a/crates/varpulis-runtime/src/engine/compilation.rs
+++ b/crates/varpulis-runtime/src/engine/compilation.rs
@@ -927,14 +927,15 @@ impl Engine {
                     }
                 }
                 StreamOp::Select(items) => {
-                    let fields: Vec<(String, varpulis_core::ast::Expr)> = items
+                    let fields: Vec<(std::sync::Arc<str>, varpulis_core::ast::Expr)> = items
                         .iter()
                         .map(|item| match item {
-                            varpulis_core::ast::SelectItem::Field(name) => {
-                                (name.clone(), varpulis_core::ast::Expr::Ident(name.clone()))
-                            }
+                            varpulis_core::ast::SelectItem::Field(name) => (
+                                std::sync::Arc::from(name.as_str()),
+                                varpulis_core::ast::Expr::Ident(name.clone()),
+                            ),
                             varpulis_core::ast::SelectItem::Alias(name, expr) => {
-                                (name.clone(), expr.clone())
+                                (std::sync::Arc::from(name.as_str()), expr.clone())
                             }
                         })
                         .collect();
@@ -955,9 +956,9 @@ impl Engine {
 
                     if has_complex_expr {
                         // Use EmitExpr for complex expressions with function evaluation
-                        let fields: Vec<(String, varpulis_core::ast::Expr)> = args
+                        let fields: Vec<(std::sync::Arc<str>, varpulis_core::ast::Expr)> = args
                             .iter()
-                            .map(|arg| (arg.name.clone(), arg.value.clone()))
+                            .map(|arg| (std::sync::Arc::from(arg.name.as_str()), arg.value.clone()))
                             .collect();
                         runtime_ops.push(RuntimeOp::EmitExpr(EmitExprConfig {
                             fields,
@@ -965,7 +966,7 @@ impl Engine {
                         }));
                     } else {
                         // Use simple EmitConfig for string/ident only
-                        let fields: Vec<(String, String)> = args
+                        let fields: Vec<(std::sync::Arc<str>, String)> = args
                             .iter()
                             .filter_map(|arg| {
                                 let value = match &arg.value {
@@ -973,7 +974,7 @@ impl Engine {
                                     varpulis_core::ast::Expr::Ident(s) => s.clone(),
                                     _ => return None,
                                 };
-                                Some((arg.name.clone(), value))
+                                Some((std::sync::Arc::from(arg.name.as_str()), value))
                             })
                             .collect();
                         runtime_ops.push(RuntimeOp::Emit(EmitConfig {

--- a/crates/varpulis-runtime/src/engine/dispatch.rs
+++ b/crates/varpulis-runtime/src/engine/dispatch.rs
@@ -254,6 +254,14 @@ impl Engine {
     }
 
     /// Process a batch of events for improved throughput (async-runtime only).
+    ///
+    /// Consecutive events with the same type (at the same chain depth) are
+    /// grouped into a **run** and pushed through the pipeline in a single
+    /// `execute_pipeline` call when the target stream is
+    /// [batch-safe](Self::stream_is_batch_safe). This amortizes the
+    /// per-event dispatch cost and — critically — lets `.to()` hand whole
+    /// batches to sink connectors instead of one event at a time. Because
+    /// runs are consecutive, global FIFO order is preserved exactly.
     #[cfg(feature = "async-runtime")]
     #[tracing::instrument(level = "trace", skip(self))]
     pub async fn process_batch(
@@ -300,10 +308,25 @@ impl Engine {
                 continue;
             }
 
+            // Gather the run: consecutive pending events with the same type
+            // and depth. Stream-local ordering is untouched (each stream
+            // still sees its events in arrival order).
+            let mut run: Vec<SharedEvent> = vec![current_event];
+            while let Some((next, next_depth)) = pending_events.front() {
+                if *next_depth == depth && next.event_type == run[0].event_type {
+                    let (event, _) = pending_events
+                        .pop_front()
+                        .expect("front() just returned Some");
+                    run.push(event);
+                } else {
+                    break;
+                }
+            }
+
             // Get stream names (Arc clone is O(1))
             let stream_names: Arc<[String]> = self
                 .router
-                .get_routes(&current_event.event_type)
+                .get_routes(&run[0].event_type)
                 .cloned()
                 .unwrap_or_else(|| Arc::from([]));
 
@@ -313,59 +336,58 @@ impl Engine {
                     if self.trace_collector.is_enabled() {
                         self.trace_collector.record(TraceEntry::StreamMatched {
                             stream_name: stream_name.clone(),
-                            event_type: current_event.event_type.to_string(),
+                            event_type: run[0].event_type.to_string(),
                         });
                     }
 
                     let start = std::time::Instant::now();
-                    let result = Self::process_stream_with_functions(
-                        stream,
-                        Arc::clone(&current_event),
-                        &self.functions,
-                        self.sinks.cache(),
-                    )
-                    .await?;
 
-                    // Record trace: pipeline result
-                    if self.trace_collector.is_enabled() {
-                        Self::record_trace_for_result(
-                            &mut self.trace_collector,
-                            stream_name,
+                    if run.len() > 1 && Self::stream_is_batch_safe(stream) {
+                        // Stateless run: one pipeline pass over the whole run.
+                        let result = Self::process_stream_run(
                             stream,
-                            &result,
+                            run.clone(),
+                            &self.functions,
+                            self.sinks.cache(),
+                        )
+                        .await?;
+                        Self::fold_stream_result(
+                            stream,
+                            stream_name,
+                            result,
+                            &mut self.trace_collector,
+                            &mut self.output_events_emitted,
+                            &mut emitted_batch,
+                            &mut pending_events,
+                            depth,
                         );
+                    } else {
+                        // Stateful/order-sensitive stream: per-event, exactly
+                        // as before.
+                        for event in &run {
+                            let result = Self::process_stream_with_functions(
+                                stream,
+                                Arc::clone(event),
+                                &self.functions,
+                                self.sinks.cache(),
+                            )
+                            .await?;
+                            Self::fold_stream_result(
+                                stream,
+                                stream_name,
+                                result,
+                                &mut self.trace_collector,
+                                &mut self.output_events_emitted,
+                                &mut emitted_batch,
+                                &mut pending_events,
+                                depth,
+                            );
+                        }
                     }
 
                     // Record per-stream processing in Prometheus
                     if let Some(ref m) = self.metrics {
                         m.record_processing(stream_name, start.elapsed().as_secs_f64());
-                    }
-
-                    // Collect emitted events for batch sending
-                    self.output_events_emitted += result.emitted_events.len() as u64;
-                    let has_emitted = !result.emitted_events.is_empty();
-                    emitted_batch.extend(result.emitted_events);
-
-                    // If .process() or .to() was used but no .emit(), send output_events
-                    // to the output channel so they appear in the live event stream.
-                    let forward_outputs = !has_emitted
-                        && stream
-                            .operations
-                            .iter()
-                            .any(|op| matches!(op, RuntimeOp::Process(_) | RuntimeOp::To(_)));
-                    if forward_outputs {
-                        self.output_events_emitted += result.output_events.len() as u64;
-                        emitted_batch.extend(result.output_events.iter().map(Arc::clone));
-                    }
-
-                    // Count sink events only when not already counted via forwarded outputs
-                    if !forward_outputs {
-                        self.output_events_emitted += result.sink_events_sent;
-                    }
-
-                    // Queue output events (push_back to maintain order)
-                    for output_event in result.output_events {
-                        pending_events.push_back((output_event, depth + 1));
                     }
                 }
             }
@@ -681,6 +703,141 @@ impl Engine {
         }
 
         Ok(())
+    }
+
+    /// Whether a whole same-type run of events can be pushed through this
+    /// stream's pipeline in one `execute_pipeline` call without changing
+    /// semantics.
+    ///
+    /// True only when every operator treats a batch exactly like a sequence
+    /// of single events: filters (`retain`), projections (per-event map),
+    /// sinks, logging, `distinct`, and `limit`. Stateful operators whose
+    /// output depends on call granularity (aggregations fire once per call,
+    /// `Pattern` matches over the current set, `Forecast` samples the first
+    /// event of the call, windows/sequences interleave with derived events)
+    /// keep the per-event path.
+    #[cfg(feature = "async-runtime")]
+    fn stream_is_batch_safe(stream: &StreamDefinition) -> bool {
+        if matches!(
+            stream.source,
+            RuntimeSource::Join(_) | RuntimeSource::Timer(_)
+        ) {
+            return false;
+        }
+        stream.operations.iter().all(|op| {
+            matches!(
+                op,
+                RuntimeOp::WhereExpr(_)
+                    | RuntimeOp::WhereClosure(_)
+                    | RuntimeOp::Emit(_)
+                    | RuntimeOp::EmitExpr(_)
+                    | RuntimeOp::Select(_)
+                    | RuntimeOp::To(_)
+                    | RuntimeOp::Print(_)
+                    | RuntimeOp::Log(_)
+                    | RuntimeOp::Alert(_)
+                    | RuntimeOp::Distinct(_)
+                    | RuntimeOp::Limit(_)
+            )
+        })
+    }
+
+    /// Run a whole same-type event run through a batch-safe stream.
+    ///
+    /// Mirrors [`Self::process_stream_with_functions`] minus the join
+    /// handling (join streams are never batch-safe).
+    #[cfg(feature = "async-runtime")]
+    async fn process_stream_run(
+        stream: &mut StreamDefinition,
+        mut events: Vec<SharedEvent>,
+        functions: &FxHashMap<String, UserFunction>,
+        sinks: &FxHashMap<String, Arc<dyn crate::sink::Sink>>,
+    ) -> Result<StreamProcessResult, super::error::EngineError> {
+        if let RuntimeSource::Merge(ref sources) = stream.source {
+            events.retain(|event| {
+                sources.iter().any(|ms| {
+                    ms.event_type == *event.event_type
+                        && ms.filter.as_ref().is_none_or(|filter| {
+                            let ctx = SequenceContext::new();
+                            evaluator::eval_expr_with_functions(
+                                filter,
+                                event,
+                                &ctx,
+                                functions,
+                                &FxHashMap::default(),
+                            )
+                            .and_then(|v| v.as_bool())
+                            .unwrap_or(false)
+                        })
+                })
+            });
+            if events.is_empty() {
+                return Ok(StreamProcessResult {
+                    emitted_events: vec![],
+                    output_events: vec![],
+                    sink_events_sent: 0,
+                });
+            }
+        }
+
+        pipeline::execute_pipeline(
+            stream,
+            events,
+            0,
+            pipeline::SkipFlags::none(),
+            functions,
+            sinks,
+        )
+        .await
+    }
+
+    /// Fold one pipeline result into the batch accumulator state: trace
+    /// entries, emitted/output counters, the emitted batch, and the pending
+    /// queue for downstream streams. Shared by the batched and per-event
+    /// dispatch paths so their bookkeeping cannot drift.
+    #[cfg(feature = "async-runtime")]
+    #[allow(clippy::too_many_arguments)]
+    fn fold_stream_result(
+        stream: &StreamDefinition,
+        stream_name: &str,
+        result: StreamProcessResult,
+        trace_collector: &mut super::trace::TraceCollector,
+        output_events_emitted: &mut u64,
+        emitted_batch: &mut Vec<SharedEvent>,
+        pending_events: &mut VecDeque<(SharedEvent, usize)>,
+        depth: usize,
+    ) {
+        // Record trace: pipeline result
+        if trace_collector.is_enabled() {
+            Self::record_trace_for_result(trace_collector, stream_name, stream, &result);
+        }
+
+        // Collect emitted events for batch sending
+        *output_events_emitted += result.emitted_events.len() as u64;
+        let has_emitted = !result.emitted_events.is_empty();
+        emitted_batch.extend(result.emitted_events);
+
+        // If .process() or .to() was used but no .emit(), send output_events
+        // to the output channel so they appear in the live event stream.
+        let forward_outputs = !has_emitted
+            && stream
+                .operations
+                .iter()
+                .any(|op| matches!(op, RuntimeOp::Process(_) | RuntimeOp::To(_)));
+        if forward_outputs {
+            *output_events_emitted += result.output_events.len() as u64;
+            emitted_batch.extend(result.output_events.iter().map(Arc::clone));
+        }
+
+        // Count sink events only when not already counted via forwarded outputs
+        if !forward_outputs {
+            *output_events_emitted += result.sink_events_sent;
+        }
+
+        // Queue output events (push_back to maintain order)
+        for output_event in result.output_events {
+            pending_events.push_back((output_event, depth + 1));
+        }
     }
 
     #[cfg(feature = "async-runtime")]

--- a/crates/varpulis-runtime/src/engine/dispatch.rs
+++ b/crates/varpulis-runtime/src/engine/dispatch.rs
@@ -257,8 +257,8 @@ impl Engine {
     ///
     /// Consecutive events with the same type (at the same chain depth) are
     /// grouped into a **run** and pushed through the pipeline in a single
-    /// `execute_pipeline` call when the target stream is
-    /// [batch-safe](Self::stream_is_batch_safe). This amortizes the
+    /// `execute_pipeline` call when the target stream is batch-safe (see
+    /// `stream_is_batch_safe`). This amortizes the
     /// per-event dispatch cost and — critically — lets `.to()` hand whole
     /// batches to sink connectors instead of one event at a time. Because
     /// runs are consecutive, global FIFO order is preserved exactly.

--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -72,6 +72,11 @@ pub(super) enum OutputChannel {
     Owned(mpsc::Sender<Event>),
     /// Zero-copy channel using SharedEvent (Arc<Event>)
     Shared(mpsc::Sender<SharedEvent>),
+    /// Drop output events entirely (long-running headless/quiet pipelines).
+    ///
+    /// Distinct from `None`, which *collects* outputs into an internal
+    /// buffer for `process_batch_sync_collect` — unbounded over a long run.
+    Discard,
 }
 
 /// The main Varpulis engine
@@ -355,6 +360,7 @@ impl Engine {
         match &self.output_channel {
             Some(OutputChannel::Owned(tx)) => Some(OutputChannel::Owned(tx.clone())),
             Some(OutputChannel::Shared(tx)) => Some(OutputChannel::Shared(tx.clone())),
+            Some(OutputChannel::Discard) => Some(OutputChannel::Discard),
             None => None,
         }
     }
@@ -414,6 +420,7 @@ impl Engine {
                     }
                 }
             }
+            Some(OutputChannel::Discard) => {}
             None => {
                 // No channel: collect into buffer for sync_collect
                 self.collected_outputs.push((**event).clone());
@@ -466,6 +473,7 @@ impl Engine {
                     }
                 }
             }
+            Some(OutputChannel::Discard) => {}
             None => {
                 self.collected_outputs.push((**event).clone());
             }
@@ -521,6 +529,7 @@ impl Engine {
                     }
                 }
             }
+            Some(OutputChannel::Discard) => {}
             None => {
                 // No channel: collect into buffer for sync_collect
                 self.collected_outputs.push(event);

--- a/crates/varpulis-runtime/src/engine/pipeline.rs
+++ b/crates/varpulis-runtime/src/engine/pipeline.rs
@@ -722,7 +722,7 @@ fn execute_op_common(
                             functions,
                             empty_vars(),
                         ) {
-                            new_event.data.insert(out_name.clone().into(), value);
+                            new_event.data.insert(Arc::clone(out_name), value);
                         }
                     }
                     Arc::new(new_event)
@@ -740,13 +740,11 @@ fn execute_op_common(
                 );
                 for (out_name, source) in &config.fields {
                     if let Some(value) = event.get(source) {
-                        new_event
-                            .data
-                            .insert(out_name.clone().into(), value.clone());
+                        new_event.data.insert(Arc::clone(out_name), value.clone());
                     } else {
                         new_event
                             .data
-                            .insert(out_name.clone().into(), Value::Str(source.clone().into()));
+                            .insert(Arc::clone(out_name), Value::Str(source.as_str().into()));
                     }
                 }
                 emitted.push(Arc::new(new_event));
@@ -779,9 +777,7 @@ fn execute_op_common(
                     for (out_name, expr) in &config.fields {
                         if let varpulis_core::ast::Expr::Ident(field_name) = expr {
                             if let Some(value) = event.get(field_name) {
-                                new_event
-                                    .data
-                                    .insert(Arc::from(out_name.as_str()), value.clone());
+                                new_event.data.insert(Arc::clone(out_name), value.clone());
                             }
                         }
                     }
@@ -802,7 +798,7 @@ fn execute_op_common(
                             functions,
                             empty_vars(),
                         ) {
-                            new_event.data.insert(out_name.clone().into(), value);
+                            new_event.data.insert(Arc::clone(out_name), value);
                         }
                     }
                     emitted.push(Arc::new(new_event));

--- a/crates/varpulis-runtime/src/engine/types.rs
+++ b/crates/varpulis-runtime/src/engine/types.rs
@@ -428,8 +428,8 @@ pub struct LimitState {
 
 /// Configuration for select/projection operation
 pub struct SelectConfig {
-    /// Fields to include: (output_name, expression)
-    pub fields: Vec<(String, varpulis_core::ast::Expr)>,
+    /// Fields to include: (output_name, expression) with pre-interned names.
+    pub fields: Vec<(std::sync::Arc<str>, varpulis_core::ast::Expr)>,
 }
 
 /// Result of processing a stream
@@ -906,14 +906,18 @@ pub enum WindowType {
 /// Configuration for simple emit operation
 #[allow(dead_code)]
 pub struct EmitConfig {
-    pub fields: Vec<(String, String)>, // (output_name, source_field or literal)
+    /// (output_name, source_field or literal). Output names are pre-interned
+    /// `Arc<str>` so the per-event emit loop clones a pointer instead of
+    /// re-allocating the key for every emitted event.
+    pub fields: Vec<(std::sync::Arc<str>, String)>,
     pub target_context: Option<String>,
 }
 
 /// Configuration for emit with expressions
 #[allow(dead_code)]
 pub struct EmitExprConfig {
-    pub fields: Vec<(String, varpulis_core::ast::Expr)>, // (output_name, expression)
+    /// (output_name, expression) with pre-interned output names.
+    pub fields: Vec<(std::sync::Arc<str>, varpulis_core::ast::Expr)>,
     pub target_context: Option<String>,
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -72,6 +72,16 @@ ignore = [
     # that logger calling rand::rng() with trace/warn logging. We don't
     # define a custom logger that uses rand, so the preconditions don't hold.
     { id = "RUSTSEC-2026-0097", reason = "preconditions not applicable — no custom logger using rand::rng()" },
+
+    # proc-macro-error2: unmaintained. Transitive via iai-callgrind-macros
+    # (dev-only benchmarks, same tree as the bincode ignore above).
+    { id = "RUSTSEC-2026-0173", reason = "dev-only transitive via iai-callgrind benchmarks" },
+
+    # quick-xml 0.26: attribute-parsing DoS advisories. Transitive via
+    # inferno → pprof (dev-only profiling); inferno pins quick-xml 0.26,
+    # fix requires >=0.41. Never parses attacker-controlled XML here.
+    { id = "RUSTSEC-2026-0194", reason = "dev-only transitive via pprof/inferno flamegraphs" },
+    { id = "RUSTSEC-2026-0195", reason = "dev-only transitive via pprof/inferno flamegraphs" },
 ]
 
 # ---------------------------------------------------------------------------

--- a/docs/comparisons/varpulis-vs-arroyo.md
+++ b/docs/comparisons/varpulis-vs-arroyo.md
@@ -350,30 +350,33 @@ stream Filtered = Tick
 
 | Engine | Throughput | Output | Input path |
 |---|---|---|---|
-| **Varpulis** | **174,751 events/sec** | 89,000 ✓ | File (JSONL via `simulate`) |
-| Arroyo | 86,398 events/sec | 89,000 ✓ | Kafka (Redpanda topic via Kafka source) |
+| **Varpulis** | **160,615 events/sec** | 89,000 ✓ | Kafka (same Redpanda topic) |
+| Arroyo | 99,016 events/sec | 89,000 ✓ | Kafka (same Redpanda topic) |
 
-Both engines deliver identical 89,000 output events, verifying correctness.
-Varpulis is roughly **2× faster** on its native input path than Arroyo on its
-native input path. The architectural reasons:
+*(July 2026, like-for-like Kafka: both engines consume the same pre-loaded
+Redpanda topic and produce to a Kafka sink. Timers start at each engine's
+readiness signal — Arroyo `state=Running`, Varpulis's run-loop marker — so
+neither engine's compile/startup is counted, and both pay their Kafka
+connect and consumer-group join inside the timed window.)*
 
-1. **Varpulis pays no broker round-trip.** File-mode reads JSONL directly from
-   the local filesystem, no network/Kafka deserialisation overhead. The
-   Arroyo path goes through Redpanda's Kafka protocol on every event.
-2. **Arroyo runs in Docker with its full cluster topology** (controller +
-   worker + Postgres) — non-trivial baseline overhead even at small
-   parallelism. Varpulis runs as a single process with a shared in-process
-   pipeline.
-3. **The Arroyo job has to compile and start before timing begins**, but
-   we exclude the compile time. The 1.16s wall time is purely the data
-   processing pass through the running pipeline.
+Both engines deliver identical output: 89,000 records, same content, same
+order. Varpulis is **1.62× faster on the identical input path**, while its
+output records additionally carry `event_type` and the event-time
+`timestamp` (more bytes per record than Arroyo emits). Where the margin
+comes from:
 
-A direct Varpulis-on-Kafka comparison (rebuilding `varpulis-cli` with
-`--features kafka` and using the same Redpanda topic) would close some of
-this gap because Varpulis would also pay the Kafka deserialisation cost.
-Architecturally we expect Varpulis-on-Kafka to land in the **130-160k
-events/sec** range based on its file-mode-vs-Kafka delta in the apama
-benchmark, leaving roughly a 1.5-2× margin over Arroyo.
+1. **Allocation-free steady-state decode.** Varpulis deserializes Kafka
+   JSON straight into its event representation with interned field names
+   and event types — no intermediate DOM, no per-record key allocations.
+2. **Run-grouped dispatch.** Consecutive same-type events flow through the
+   operator pipeline as one batch, so the Kafka sink receives whole
+   batches per enqueue pass rather than per-event async calls.
+3. **Single-process pipeline.** Arroyo runs its cluster topology
+   (controller + worker + Postgres) even at parallelism 1; Varpulis runs
+   one process with an in-process pipeline.
+
+For pure engine-core throughput without a broker, Varpulis file-mode
+(`varpulis simulate`) measures 174,751 events/sec on the same workload.
 
 ### What we did NOT yet measure
 
@@ -384,8 +387,6 @@ benchmark, leaving roughly a 1.5-2× margin over Arroyo.
   same generator drives both engines without schema changes. The infrastructure
   in `benchmarks/arroyo-comparison/` has the SQL written; only the data
   generator update is needed.
-- **Like-for-like Kafka comparison** (both engines on Kafka): requires
-  rebuilding Varpulis with `--features kafka`. Pending.
 - **Native pattern detection workloads** (sequence, Kleene closure,
   forecasting): Arroyo has no native implementation, so the only comparison
   would be Varpulis's NFA vs a hand-coded Rust UDAF — that's not engine-vs-


### PR DESCRIPTION
## Summary

Varpulis now **beats Arroyo 1.6–1.9x** on the like-for-like Kafka benchmark (scenario 01_filter, both engines on the same Redpanda topic). The 2026-04 baseline had Varpulis *losing* at 0.91x (88.5k vs 96.7k eps); this PR lands at **160.6k vs 99.0k eps** with byte-identical output (verified: same 89,000 records, same order).

| | Varpulis | Arroyo | ratio |
|---|---|---|---|
| 2026-04 baseline | 88,507 eps | 96,750 eps | 0.91x |
| this PR (5-run median) | **160,615 eps** | 99,016 eps | **1.62x** |

## Engine hot-path work (`perf(kafka)` commit, +37% under unchanged timing)

- **Streaming JSON→Event decoder** (`EventDecoder`): deserializes payloads directly into `Event` via `DeserializeSeed` with per-task interned field names/event types — no intermediate `serde_json::Value` tree, zero key allocations in steady state. Same resource limits; equivalence-tested against `json_to_event`.
- **Run-grouped batch dispatch**: consecutive same-type events go through `execute_pipeline` as one batch when all operators are batch-safe (filters/projections/sinks/log/distinct/limit). Stateful operators keep the per-event path; FIFO order preserved exactly.
- **Native `KafkaSharedSink::send_batch`**: reused serialization buffer, one call per batch instead of a boxed async call per event. Also fixes `send_batch_to_topic` silently ignoring the topic (dynamic topic routing bug on managed Kafka sinks).
- **Interned emit/select output names** (built at compile time, `Arc<str>` clone per event instead of two allocations per field).
- **`OutputChannel::Discard`** for `run --quiet` (previously deep-cloned every emitted event into a drained channel); non-quiet uses the zero-copy shared channel.
- **mimalloc** as the CLI global allocator; circuit breaker off the consume loop's happy path.

## Benchmark methodology fix (`bench(arroyo)` commit)

The harness timed Arroyo from pipeline `state=Running` (SQL compile/deploy excluded) but Varpulis from process spawn (~113 ms of binary load + parse + connector init included). Timing now starts at Varpulis's readiness marker — symmetric; both engines pay Kafka connect + consumer-group join inside the timed window. `results/01_filter.json` documents the engine-gain vs methodology split.

## Dependency advisories (`deps` commit)

`cargo deny`/`cargo audit` were failing on 12 pre-existing RUSTSECs. Fixed 9 via semver-compatible updates (anyhow, crossbeam-epoch, lettre, memmap2, postgres-protocol, tokio-postgres, quinn-proto, rmcp 1.4 + macro-API adjustment in varpulis-mcp), ignored 3 dev-only transitive ones with reasons mirrored in `deny.toml` and `.cargo/audit.toml`.

Also includes the `--code` long-only CLI fix (7e53485, already on its own pushed branch) which the benchmark harness depends on.

## Test plan

- [x] ~800 local tests green: runtime lib + golden + engine/checkpoint/context/window/aggregation integration, CLI, connector-api (incl. new decoder equivalence tests), varpulis-mcp
- [x] `make verify` green (fmt, clippy workspace via push gate, audit, deny)
- [x] Benchmark reproduced post-commit (1.93x on a 3-run confirmation)
- [x] Output content verified identical to Arroyo record-for-record
- [x] File-mode `simulate` smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vR5wHzbtcHxj5ZcdB4AP