### PR TITLE
fix(runtime): Phase 1 — preserve cross-stream FIFO interleave in run-grouped dispatch

### DIFF
--- a/crates/varpulis-runtime/src/engine/dispatch.rs
+++ b/crates/varpulis-runtime/src/engine/dispatch.rs
@@ -308,27 +308,35 @@ impl Engine {
                 continue;
             }
 
-            // Gather the run: consecutive pending events with the same type
-            // and depth. Stream-local ordering is untouched (each stream
-            // still sees its events in arrival order).
-            let mut run: Vec<SharedEvent> = vec![current_event];
-            while let Some((next, next_depth)) = pending_events.front() {
-                if *next_depth == depth && next.event_type == run[0].event_type {
-                    let (event, _) = pending_events
-                        .pop_front()
-                        .expect("front() just returned Some");
-                    run.push(event);
-                } else {
-                    break;
-                }
-            }
-
-            // Get stream names (Arc clone is O(1))
+            // Get stream names for this event type (Arc clone is O(1)).
             let stream_names: Arc<[String]> = self
                 .router
-                .get_routes(&run[0].event_type)
+                .get_routes(&current_event.event_type)
                 .cloned()
                 .unwrap_or_else(|| Arc::from([]));
+
+            // Gather a run of consecutive pending events of the same type and
+            // depth — but ONLY when the type routes to a single stream. With
+            // multiple target streams, batching a whole run and processing it
+            // per-stream would emit [S,S,T,T], whereas the per-event dispatch
+            // paths (process_inner / process_batch_shared) emit the interleaved
+            // [S,T,S,T]; a downstream merge/sequence consuming both S and T
+            // would then observe a different event order depending on batch
+            // boundaries. Single-target runs have no cross-stream interleave,
+            // so batching stays safe (and beneficial) there.
+            let mut run: Vec<SharedEvent> = vec![current_event];
+            if stream_names.len() == 1 {
+                while let Some((next, next_depth)) = pending_events.front() {
+                    if *next_depth == depth && next.event_type == run[0].event_type {
+                        let (event, _) = pending_events
+                            .pop_front()
+                            .expect("front() just returned Some");
+                        run.push(event);
+                    } else {
+                        break;
+                    }
+                }
+            }
 
             for stream_name in stream_names.iter() {
                 if let Some(stream) = self.streams.get_mut(stream_name) {

--- a/crates/varpulis-runtime/tests/engine_pipeline_extended_tests.rs
+++ b/crates/varpulis-runtime/tests/engine_pipeline_extended_tests.rs
@@ -1441,3 +1441,50 @@ async fn sync_first_shorthand() {
     );
     assert_eq!(out[0].data.get("val"), Some(&Value::Int(1)));
 }
+
+// ---------------------------------------------------------------------------
+// Run-grouping must preserve cross-stream FIFO interleave (audit Phase 1)
+// ---------------------------------------------------------------------------
+
+/// Regression: PR #164's run-grouping in `process_batch` gathered a run of
+/// same-type events and processed the whole run per target stream, emitting
+/// `[S,S,T,T]` when an event type routes to two streams — whereas the per-event
+/// dispatch paths emit the interleaved `[S,T,S,T]`. A downstream merge/sequence
+/// consuming both S and T would see a different order depending on batch
+/// boundaries. The fix restricts run-grouping to single-target event types.
+#[tokio::test]
+async fn process_batch_preserves_cross_stream_interleave() {
+    let code = r#"
+        stream S = A .emit(tag: "S")
+        stream T = A .emit(tag: "T")
+    "#;
+    let program = parse(code).expect("parse");
+    let (tx, mut rx) = mpsc::channel(4096);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).unwrap();
+
+    let events: Vec<Event> = vec![
+        Event::new("A").with_field("n", Value::Int(1)),
+        Event::new("A").with_field("n", Value::Int(2)),
+    ];
+    engine.process_batch(events).await.unwrap();
+
+    let mut order = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        order.push(e.event_type.to_string());
+    }
+
+    // Two A events × two streams = 4 outputs. Each source event must produce
+    // one S and one T *interleaved* — i.e. the first two outputs are different
+    // streams (not the [S,S,...] grouping the bug produced), and so are the
+    // last two.
+    assert_eq!(order.len(), 4, "expected 4 emitted events, got {order:?}");
+    assert_ne!(
+        order[0], order[1],
+        "first source event's outputs must interleave the streams, not group [S,S,..]: {order:?}"
+    );
+    assert_ne!(
+        order[2], order[3],
+        "second source event's outputs must interleave the streams: {order:?}"
+    );
+}


### PR DESCRIPTION
First Phase 1 fix from the audit remediation (plan: `.claude/plans/rippling-moseying-breeze.md`). This repairs a correctness **regression I introduced in PR #164**.

## The bug
PR #164's run-grouping in `process_batch` gathered a run of consecutive same-type events and processed the **whole run per target stream**. When an event type routes to two streams `S` and `T`, that emits `[S,S,T,T]` — whereas the per-event dispatch paths (`process_inner` / `process_batch_shared`) emit the interleaved `[S,T,S,T]`. A downstream `merge`/sequence stream consuming both `S` and `T` would then observe a **different event order depending on batch boundaries**. `process_batch` is the default `run`/sink path, so this was live.

## The fix
Only gather a run when the event type routes to a **single** stream. With multiple targets the run stays one event, processed per-event through each stream — restoring `[S,T,S,T]`. Single-target runs (the common case) have no cross-stream interleave, so batching stays safe and beneficial. Stream names are now resolved from the current event *before* run-gathering.

## Test
`process_batch_preserves_cross_stream_interleave` — **verified failing** on the pre-fix behavior (`["S","S","T","T"]`), passes after (`[S,T,S,T]`).

## Test plan
- [x] New regression test fails-before / passes-after
- [x] 558 runtime-lib + engine_pipeline_extended (61) + engine_tests (127) + backpressure + edge_pipeline — all green
- [x] `make verify` green

Next Phase 1 pieces (separate PRs, given their care needs): C1 checkpoint un-fusing, parser-safety, then the watermark refactor (C2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vR5wHzbtcHxj5ZcdB4AP