### PR TITLE
fix(core): Phase 1 — parser/evaluator safety (checked arithmetic, timestamp overflow, map Hash/Eq)

### DIFF
--- a/crates/varpulis-core/src/value.rs
+++ b/crates/varpulis-core/src/value.rs
@@ -318,10 +318,20 @@ impl Hash for Value {
             }
             Self::Map(map) => {
                 map.len().hash(state);
+                // Order-independent: `PartialEq` for maps is order-independent
+                // (indexmap compares by content), so the hash must be too, or
+                // equal maps built in different insertion orders would hash
+                // differently — violating the Hash/Eq contract. Combine each
+                // entry's hash with XOR (commutative) rather than feeding them
+                // to the hasher in iteration order.
+                let mut combined: u64 = 0;
                 for (k, v) in map.iter() {
-                    k.hash(state);
-                    v.hash(state);
+                    let mut entry_hasher = std::collections::hash_map::DefaultHasher::new();
+                    k.hash(&mut entry_hasher);
+                    v.hash(&mut entry_hasher);
+                    combined ^= entry_hasher.finish();
                 }
+                combined.hash(state);
             }
         }
     }
@@ -749,6 +759,38 @@ mod tests {
             hash_value(&Value::Float(f64::NAN)),
             hash_value(&Value::Float(f64::NAN))
         );
+    }
+
+    #[test]
+    fn test_hash_map_order_independent() {
+        use std::collections::hash_map::DefaultHasher;
+        use std::hash::{Hash, Hasher};
+
+        use indexmap::IndexMap;
+        use rustc_hash::FxBuildHasher;
+
+        fn hash_value(v: &Value) -> u64 {
+            let mut hasher = DefaultHasher::new();
+            v.hash(&mut hasher);
+            hasher.finish()
+        }
+
+        let mut a: IndexMap<std::sync::Arc<str>, Value, FxBuildHasher> =
+            IndexMap::with_hasher(FxBuildHasher);
+        a.insert("x".into(), Value::Int(1));
+        a.insert("y".into(), Value::Int(2));
+
+        let mut b: IndexMap<std::sync::Arc<str>, Value, FxBuildHasher> =
+            IndexMap::with_hasher(FxBuildHasher);
+        b.insert("y".into(), Value::Int(2));
+        b.insert("x".into(), Value::Int(1));
+
+        let va = Value::map(a);
+        let vb = Value::map(b);
+        // Equal under PartialEq (order-independent)...
+        assert_eq!(va, vb);
+        // ...therefore must hash equal (Hash/Eq contract).
+        assert_eq!(hash_value(&va), hash_value(&vb));
     }
 
     #[test]

--- a/crates/varpulis-parser/src/helpers.rs
+++ b/crates/varpulis-parser/src/helpers.rs
@@ -87,7 +87,10 @@ pub fn parse_timestamp(s: &str) -> i64 {
     // Days
     days += (day - 1) as i64;
 
-    let mut seconds = days * 86400;
+    // Saturating throughout: an out-of-range year (the grammar allows up to
+    // 9999, whose nanosecond value exceeds i64) must not panic the parser on
+    // user input — it clamps instead.
+    let mut seconds = days.saturating_mul(86400);
 
     // Parse time if present
     if let Some(time_str) = time_part {
@@ -110,7 +113,12 @@ pub fn parse_timestamp(s: &str) -> i64 {
             } else {
                 0
             };
-            seconds += hours * 3600 + minutes * 60 + secs;
+            seconds = seconds.saturating_add(
+                hours
+                    .saturating_mul(3600)
+                    .saturating_add(minutes.saturating_mul(60))
+                    .saturating_add(secs),
+            );
         }
 
         // Handle timezone offset (simplified - just adjust hours)
@@ -118,19 +126,19 @@ pub fn parse_timestamp(s: &str) -> i64 {
             let tz = &time_str[tz_idx + 1..];
             if let Some(colon_idx) = tz.find(':') {
                 let tz_hours: i64 = tz[..colon_idx].parse().unwrap_or(0);
-                seconds -= tz_hours * 3600;
+                seconds = seconds.saturating_sub(tz_hours.saturating_mul(3600));
             }
         } else if let Some(tz_idx) = time_str[1..].find('-') {
             let tz = &time_str[tz_idx + 2..];
             if let Some(colon_idx) = tz.find(':') {
                 let tz_hours: i64 = tz[..colon_idx].parse().unwrap_or(0);
-                seconds += tz_hours * 3600;
+                seconds = seconds.saturating_add(tz_hours.saturating_mul(3600));
             }
         }
     }
 
     // Convert to nanoseconds
-    seconds * 1_000_000_000
+    seconds.saturating_mul(1_000_000_000)
 }
 
 const fn is_leap_year(year: i32) -> bool {
@@ -140,6 +148,17 @@ const fn is_leap_year(year: i32) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_timestamp_extreme_year_does_not_panic() {
+        // The grammar allows 4-digit years; a year whose nanosecond value
+        // exceeds i64 (≥ ~2263) previously overflowed and panicked the parser
+        // on user input. It now saturates instead of panicking.
+        let ns = parse_timestamp("9999-12-31T23:59:59Z");
+        assert_eq!(ns, i64::MAX, "out-of-range timestamp saturates");
+        // A representable timestamp is unaffected.
+        assert!(parse_timestamp("2020-01-01T00:00:00Z") > 0);
+    }
 
     #[test]
     fn test_parse_duration_seconds() {

--- a/crates/varpulis-runtime/src/engine/evaluator.rs
+++ b/crates/varpulis-runtime/src/engine/evaluator.rs
@@ -1271,7 +1271,9 @@ pub fn eval_expr_with_functions(
 
             match op {
                 BinOp::Add => match (&left_val, &right_val) {
-                    (Value::Int(a), Value::Int(b)) => Some(Value::Int(a + b)),
+                    // Checked: overflow yields None (dropped) rather than
+                    // panicking the worker in overflow-checked builds.
+                    (Value::Int(a), Value::Int(b)) => a.checked_add(*b).map(Value::Int),
                     (Value::Float(a), Value::Float(b)) => Some(Value::Float(a + b)),
                     (Value::Int(a), Value::Float(b)) => Some(Value::Float(*a as f64 + b)),
                     (Value::Float(a), Value::Int(b)) => Some(Value::Float(a + *b as f64)),
@@ -1286,21 +1288,22 @@ pub fn eval_expr_with_functions(
                     _ => None,
                 },
                 BinOp::Sub => match (&left_val, &right_val) {
-                    (Value::Int(a), Value::Int(b)) => Some(Value::Int(a - b)),
+                    (Value::Int(a), Value::Int(b)) => a.checked_sub(*b).map(Value::Int),
                     (Value::Float(a), Value::Float(b)) => Some(Value::Float(a - b)),
                     (Value::Int(a), Value::Float(b)) => Some(Value::Float(*a as f64 - b)),
                     (Value::Float(a), Value::Int(b)) => Some(Value::Float(a - *b as f64)),
                     _ => None,
                 },
                 BinOp::Mul => match (&left_val, &right_val) {
-                    (Value::Int(a), Value::Int(b)) => Some(Value::Int(a * b)),
+                    (Value::Int(a), Value::Int(b)) => a.checked_mul(*b).map(Value::Int),
                     (Value::Float(a), Value::Float(b)) => Some(Value::Float(a * b)),
                     (Value::Int(a), Value::Float(b)) => Some(Value::Float(*a as f64 * b)),
                     (Value::Float(a), Value::Int(b)) => Some(Value::Float(a * *b as f64)),
                     _ => None,
                 },
                 BinOp::Div => match (&left_val, &right_val) {
-                    (Value::Int(a), Value::Int(b)) if *b != 0 => Some(Value::Int(a / b)),
+                    // checked_div covers both divide-by-zero and i64::MIN / -1.
+                    (Value::Int(a), Value::Int(b)) => a.checked_div(*b).map(Value::Int),
                     (Value::Float(a), Value::Float(b)) if *b != 0.0 => Some(Value::Float(a / b)),
                     (Value::Int(a), Value::Float(b)) if *b != 0.0 => {
                         Some(Value::Float(*a as f64 / b))
@@ -1349,7 +1352,8 @@ pub fn eval_expr_with_functions(
                     _ => None,
                 },
                 BinOp::Mod => match (&left_val, &right_val) {
-                    (Value::Int(a), Value::Int(b)) if *b != 0 => Some(Value::Int(a % b)),
+                    // checked_rem covers both modulo-by-zero and i64::MIN % -1.
+                    (Value::Int(a), Value::Int(b)) => a.checked_rem(*b).map(Value::Int),
                     (Value::Float(a), Value::Float(b)) if *b != 0.0 => Some(Value::Float(a % b)),
                     (Value::Int(a), Value::Float(b)) if *b != 0.0 => {
                         Some(Value::Float(*a as f64 % b))

--- a/crates/varpulis-runtime/tests/evaluator_coverage_tests.rs
+++ b/crates/varpulis-runtime/tests/evaluator_coverage_tests.rs
@@ -1875,3 +1875,42 @@ async fn where_ge_int_field_below_float_threshold_drops_event() {
     let out = run(code, evt).await;
     assert_eq!(out.len(), 0, "98 >= 98.6 is false; event must be dropped");
 }
+
+// =============================================================================
+// Integer arithmetic overflow is checked, not panicking (audit Phase 1)
+// =============================================================================
+
+#[tokio::test]
+async fn int_add_overflow_does_not_panic() {
+    // `x + 1` with x == i64::MAX previously panicked in overflow-checked builds
+    // (a worker-crashing DoS reachable from event data). Now the overflow
+    // yields None, the filter treats it as false and drops the event, and no
+    // panic occurs.
+    let code = r"
+        stream S = E
+            .where(x + 1 > 0)
+            .emit(v: x)
+    ";
+    let evt = Event::new("E").with_field("x", Value::Int(i64::MAX));
+    let out = run(code, evt).await;
+    assert_eq!(
+        out.len(),
+        0,
+        "overflowing arithmetic must not emit — and must not panic"
+    );
+}
+
+#[tokio::test]
+async fn int_arithmetic_still_works_without_overflow() {
+    let code = r"
+        stream S = E
+            .emit(sum: x + y, prod: x * y)
+    ";
+    let evt = Event::new("E")
+        .with_field("x", Value::Int(6))
+        .with_field("y", Value::Int(7));
+    let out = run(code, evt).await;
+    assert_eq!(out.len(), 1);
+    assert_eq!(out[0].data.get("sum"), Some(&Value::Int(13)));
+    assert_eq!(out[0].data.get("prod"), Some(&Value::Int(42)));
+}


### PR DESCRIPTION
Audit Phase 1 (1e) — three contained correctness/DoS fixes, each with a **fail-before/pass-after** regression test.

- **Checked integer arithmetic** (`evaluator.rs`): `Int` `+`/`-`/`*`/`/`/`%` now use `checked_*` and map overflow (plus `i64::MIN / -1` and divide/modulo-by-zero) to `None`, instead of the raw `a + b` that **panicked the worker task in overflow-checked builds** on attacker-influenced event data (e.g. `.where(x + 1 > 0)` with `x == i64::MAX`).
- **Timestamp parse overflow** (`parser/helpers.rs`): `parse_timestamp` did unchecked `days * 86400` and `seconds * 1_000_000_000`; the grammar allows 4-digit years, and any year whose nanosecond value exceeds i64 (≥ ~2263) overflowed → **panic on user VPL**. The arithmetic is now saturating (the fn returns a bare `i64` with `0` as its parse-error sentinel, so a `Result` signature change would ripple to every caller).
- **`Value::Map` Hash/Eq contract** (`core/value.rs`): the map hash iterated in insertion order while `PartialEq` is order-independent, so two equal maps built in different orders hashed differently — broken for any `HashMap<Value,_>`/`HashSet<Value>`. The map arm now XOR-combines per-entry hashes.

Deferred (distinct — a runtime string-value change): string-literal escape decoding.

## Test plan
- [x] `parse_timestamp_extreme_year_does_not_panic`, `int_add_overflow_does_not_panic`, `test_hash_map_order_independent` — each fails before / passes after
- [x] 558 runtime-lib + evaluator (87) + parser (147) + core hash suites green (no regression from checked arithmetic)
- [x] `make verify` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vR5wHzbtcHxj5ZcdB4AP