### PR TITLE
fix(engine): checkpoint windowed aggregate state (audit C1)

### DIFF
--- a/crates/varpulis-cli/src/commands/run.rs
+++ b/crates/varpulis-cli/src/commands/run.rs
@@ -117,6 +117,11 @@ pub async fn run_program(
     if let Some(store) = credentials_store {
         engine = engine.credentials(store);
     }
+    // Declare checkpoint intent BEFORE load so the compiler keeps windowed
+    // aggregate state in checkpointable ops (skips columnar-aggregate fusion).
+    // enable_checkpointing() below runs after load, which is too late to gate
+    // fusion.
+    engine = engine.plan_checkpointing(checkpoint_dir.is_some());
     let mut engine = engine.build();
     engine
         .load_with_source(source, &program)

--- a/crates/varpulis-cli/src/commands/simulate.rs
+++ b/crates/varpulis-cli/src/commands/simulate.rs
@@ -135,14 +135,20 @@ pub async fn run_simulation(
     // Create initial engine to show metrics
     // In quiet mode, use benchmark engine to skip channel overhead entirely
     // PERF: Use new_shared() for zero-copy SharedEvent channel
+    // Declare checkpoint intent up front so the compiler keeps windowed
+    // aggregate state in checkpointable ops (skips columnar-aggregate fusion);
+    // enable_checkpointing() below runs after load, too late to gate fusion.
+    let plan_ckpt = checkpoint_dir.is_some();
     let mut engine = if quiet {
-        let mut b = Engine::builder();
+        let mut b = Engine::builder().plan_checkpointing(plan_ckpt);
         if let Some(ref store) = credentials_store {
             b = b.credentials(Arc::clone(store));
         }
         b.build()
     } else {
-        let mut b = Engine::builder().shared_output(output_tx.clone());
+        let mut b = Engine::builder()
+            .shared_output(output_tx.clone())
+            .plan_checkpointing(plan_ckpt);
         if let Some(ref store) = credentials_store {
             b = b.credentials(Arc::clone(store));
         }

--- a/crates/varpulis-runtime/src/engine/builder.rs
+++ b/crates/varpulis-runtime/src/engine/builder.rs
@@ -62,6 +62,7 @@ pub struct EngineBuilder {
     dlq_config: DlqConfig,
     udf_registry: UdfRegistry,
     credentials_store: Option<Arc<connector::credentials::CredentialsStore>>,
+    checkpoint_planned: bool,
 }
 
 impl Default for EngineBuilder {
@@ -81,7 +82,21 @@ impl EngineBuilder {
             dlq_config: DlqConfig::default(),
             udf_registry: UdfRegistry::new(),
             credentials_store: None,
+            checkpoint_planned: false,
         }
+    }
+
+    /// Declare that checkpointing will be enabled on this engine.
+    ///
+    /// Must be called before `build()`/`load()`. It makes the compiler skip
+    /// columnar-aggregate fusion so windowed aggregate state stays in the
+    /// checkpointable classic `Window`+`Aggregate` ops. Fusion happens during
+    /// `load()`, whereas [`Engine::enable_checkpointing`] runs afterwards — so
+    /// the intent has to be known up front, or the fused ops' state is silently
+    /// dropped on restore (broken exactly-once on the default arrow build).
+    pub fn plan_checkpointing(mut self, planned: bool) -> Self {
+        self.checkpoint_planned = planned;
+        self
     }
 
     /// Set the output channel for emitted events (legacy owned channel).
@@ -164,6 +179,7 @@ impl EngineBuilder {
         engine.dlq_config = self.dlq_config;
         engine.udf_registry = self.udf_registry;
         engine.credentials_store = self.credentials_store;
+        engine.checkpoint_planned = self.checkpoint_planned;
         engine
     }
 }

--- a/crates/varpulis-runtime/src/engine/compilation.rs
+++ b/crates/varpulis-runtime/src/engine/compilation.rs
@@ -853,8 +853,12 @@ impl Engine {
                     // `docs/development/columnar-aggregation-plan.md`.
                     #[cfg(feature = "arrow")]
                     {
+                        // Skip fusion when checkpointing is planned: the fused
+                        // columnar op's per-bin state is not captured by
+                        // checkpoint/restore, so we keep the classic
+                        // Window+Aggregate path (which is) instead.
                         if let Some(ref key) = partition_key {
-                            if aggregator.supported_for_columnar() {
+                            if !self.checkpoint_planned && aggregator.supported_for_columnar() {
                                 if let Some(crate::engine::types::RuntimeOp::Window(
                                     crate::engine::types::WindowType::PartitionedTumbling(w),
                                 )) = runtime_ops.last()
@@ -889,7 +893,13 @@ impl Engine {
                     // `Window(Tumbling) + Aggregate`.
                     #[cfg(feature = "arrow")]
                     {
-                        if partition_key.is_none() && aggregator.supported_for_columnar() {
+                        // Skip fusion when checkpointing is planned (see the
+                        // partitioned case above) — keep the checkpointable
+                        // classic Window+Aggregate path.
+                        if !self.checkpoint_planned
+                            && partition_key.is_none()
+                            && aggregator.supported_for_columnar()
+                        {
                             if let Some(crate::engine::types::RuntimeOp::Window(
                                 crate::engine::types::WindowType::Tumbling(w),
                             )) = runtime_ops.last()
@@ -2425,6 +2435,96 @@ mod arrow_fusion_tests {
             !ops.iter()
                 .any(|n| *n == "Window" || *n == "PartitionedAggregate"),
             "fusion should remove Window and PartitionedAggregate; got {ops:?}"
+        );
+    }
+
+    /// Like [`compile`], but declares checkpointing up front via
+    /// `plan_checkpointing(true)`.
+    fn compile_planned(source: &str) -> Vec<&'static str> {
+        let mut engine = Engine::builder().plan_checkpointing(true).build();
+        let program =
+            varpulis_parser::parse(source).unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+        engine
+            .load(&program)
+            .unwrap_or_else(|e| panic!("load failed: {e}"));
+        let stream_names = engine.stream_names();
+        let stream_name = stream_names.first().expect("at least one stream");
+        let stream = engine.streams.get(*stream_name).expect("stream registered");
+        stream
+            .operations
+            .iter()
+            .map(|op| op.summary_name())
+            .collect()
+    }
+
+    #[test]
+    fn checkpoint_planned_skips_partition_window_fusion() {
+        // Same Scenario-02 shape as the fusion test, but with checkpointing
+        // planned. Fusion would move the windowed aggregate state into the
+        // NOT-checkpointed columnar op (audit C1), silently losing it on
+        // restore. plan_checkpointing(true) must keep the classic
+        // Window+PartitionedAggregate ops, whose state IS checkpointed.
+        let source = r"
+            event Reading:
+                ts: int
+                device_id: str
+                temperature: float
+
+            stream DeviceAgg = Reading
+                .partition_by(device_id)
+                .window(1s)
+                .aggregate(
+                    s: sum(temperature),
+                    a: avg(temperature),
+                    mn: min(temperature),
+                    mx: max(temperature)
+                )
+                .emit(device_id: device_id, s: s, a: a, mn: mn, mx: mx)
+        ";
+        // Sanity: without planning, this pipeline DOES fuse (guards the test
+        // against the fusion path silently going away).
+        assert!(
+            compile(source).contains(&"PartitionedWindowedColumnarAggregate"),
+            "control: default build should still fuse"
+        );
+        let ops = compile_planned(source);
+        assert!(
+            !ops.contains(&"PartitionedWindowedColumnarAggregate"),
+            "checkpoint-planned build must NOT fuse; got {ops:?}"
+        );
+        assert!(
+            ops.contains(&"Window") && ops.contains(&"PartitionedAggregate"),
+            "checkpoint-planned build must keep the checkpointable \
+             Window+PartitionedAggregate ops; got {ops:?}"
+        );
+    }
+
+    #[test]
+    fn checkpoint_planned_skips_nonpartitioned_window_fusion() {
+        // Non-partitioned variant exercises the other fusion block
+        // (compile_ops_with_sequences, non-partitioned branch).
+        let source = r"
+            event Reading:
+                ts: int
+                temperature: float
+
+            stream Agg = Reading
+                .window(1s)
+                .aggregate(s: sum(temperature), a: avg(temperature))
+                .emit(s: s, a: a)
+        ";
+        assert!(
+            compile(source).contains(&"WindowedColumnarAggregate"),
+            "control: default build should still fuse the non-partitioned window"
+        );
+        let ops = compile_planned(source);
+        assert!(
+            !ops.contains(&"WindowedColumnarAggregate"),
+            "checkpoint-planned build must NOT fuse non-partitioned window; got {ops:?}"
+        );
+        assert!(
+            ops.contains(&"Window") && ops.contains(&"Aggregate"),
+            "checkpoint-planned build must keep Window+Aggregate; got {ops:?}"
         );
     }
 

--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -61,7 +61,7 @@ use crate::sase_persistence::SaseCheckpointExt;
 use crate::sequence::SequenceContext;
 use crate::udf::UdfRegistry;
 use crate::watermark::PerSourceWatermarkTracker;
-use crate::window::CountWindow;
+use crate::window::{CountWindow, SlidingCountWindow};
 
 /// Output channel type enumeration for zero-copy or owned event sending.
 /// Only available with async-runtime (requires tokio mpsc channels).
@@ -144,6 +144,14 @@ pub struct Engine {
         Vec<std::sync::Arc<std::sync::Mutex<crate::hamlet::HamletAggregator>>>,
     /// Auto-checkpointing manager (None = checkpointing disabled)
     pub(super) checkpoint_manager: Option<crate::persistence::CheckpointManager>,
+    /// When true, the compiler skips columnar-aggregate fusion so windowed
+    /// aggregate state stays in checkpointable ops (the classic
+    /// `Window`+`Aggregate` path). Set before `load()` — e.g. via
+    /// [`EngineBuilder::plan_checkpointing`] — because fusion happens during
+    /// `load()` while `enable_checkpointing` runs afterwards. Without this,
+    /// the fused columnar ops carry state that checkpoint/restore does not
+    /// capture, silently breaking exactly-once on the default (arrow) build.
+    pub(super) checkpoint_planned: bool,
     /// Async checkpoint manager for non-blocking persistence (Chandy-Lamport mode)
     #[cfg(feature = "async-runtime")]
     pub(super) async_checkpoint_manager: Option<crate::persistence::AsyncCheckpointManager>,
@@ -288,6 +296,7 @@ impl Engine {
             transactional_id_prefix: None,
             shared_hamlet_aggregators: Vec::new(),
             checkpoint_manager: None,
+            checkpoint_planned: false,
             #[cfg(feature = "async-runtime")]
             async_checkpoint_manager: None,
             credentials_store: None,
@@ -338,6 +347,7 @@ impl Engine {
                 transactional_id_prefix: None,
                 shared_hamlet_aggregators: Vec::new(),
                 checkpoint_manager: None,
+                checkpoint_planned: false,
                 dlq_path: None,
                 dlq_config: crate::dead_letter::DlqConfig::default(),
                 dlq: None,
@@ -1814,6 +1824,39 @@ impl Engine {
                             },
                         );
                     }
+                    RuntimeOp::PartitionedSlidingCountWindow(pw) => {
+                        // Per-partition sliding-count buffers hold live events;
+                        // snapshot each like PartitionedWindow. (The
+                        // `events_since_emit` slide counter is intentionally
+                        // reset to 0 on restore — a fidelity quirk shared with
+                        // the non-partitioned `SlidingCount` arm above.)
+                        let mut partitions = std::collections::HashMap::new();
+                        for (key, scw) in &pw.windows {
+                            let sub_cp = scw.checkpoint();
+                            partitions.insert(
+                                key.clone(),
+                                crate::persistence::PartitionedWindowCheckpoint {
+                                    events: sub_cp.events,
+                                    window_start_ms: sub_cp.window_start_ms,
+                                },
+                            );
+                        }
+                        window_states.insert(
+                            name.clone(),
+                            WindowCheckpoint {
+                                events: Vec::new(),
+                                window_start_ms: None,
+                                last_emit_ms: None,
+                                partitions,
+                            },
+                        );
+                    }
+                    // Aggregate/PartitionedAggregate hold only config plus a
+                    // rebuildable schema cache; their running state lives in the
+                    // upstream Window op (snapshotted above). Explicit no-op so
+                    // this stays a deliberate decision — not a silent catch-all
+                    // miss that drops fused-vs-classic state on restore (C1).
+                    RuntimeOp::Aggregate(_) | RuntimeOp::PartitionedAggregate(_) => {}
                     RuntimeOp::Distinct(state) => {
                         let keys: Vec<String> =
                             state.seen.iter().rev().map(|(k, ())| k.clone()).collect();
@@ -1924,6 +1967,20 @@ impl Engine {
                                 window.restore(&sub_wcp);
                             }
                         }
+                        RuntimeOp::PartitionedSlidingCountWindow(pw) => {
+                            for (key, pcp) in &wcp.partitions {
+                                let sub_wcp = crate::persistence::WindowCheckpoint {
+                                    events: pcp.events.clone(),
+                                    window_start_ms: pcp.window_start_ms,
+                                    last_emit_ms: None,
+                                    partitions: std::collections::HashMap::new(),
+                                };
+                                let window = pw.windows.entry(key.clone()).or_insert_with(|| {
+                                    SlidingCountWindow::new(pw.window_size, pw.slide_size)
+                                });
+                                window.restore(&sub_wcp);
+                            }
+                        }
                         _ => {}
                     }
                 }
@@ -1990,6 +2047,32 @@ impl Engine {
         store: std::sync::Arc<dyn crate::persistence::StateStore>,
         config: crate::persistence::CheckpointConfig,
     ) -> Result<(), crate::persistence::StoreError> {
+        // Fusion happens during load(); if the engine was loaded without
+        // declaring checkpoint intent (EngineBuilder::plan_checkpointing), any
+        // fused columnar-aggregate ops are already compiled and their per-bin
+        // window state is NOT captured by checkpoint/restore. Warn loudly
+        // rather than lose that state silently on recovery.
+        #[cfg(feature = "arrow")]
+        if !self.checkpoint_planned {
+            let has_fused = self.streams.values().any(|s| {
+                s.operations.iter().any(|op| {
+                    matches!(
+                        op,
+                        RuntimeOp::WindowedColumnarAggregate(_)
+                            | RuntimeOp::PartitionedWindowedColumnarAggregate(_)
+                    )
+                })
+            });
+            if has_fused {
+                warn!(
+                    "enable_checkpointing: pipeline contains fused columnar-aggregate \
+                     ops whose windowed state is NOT checkpointed — restore will lose it. \
+                     Build the engine with EngineBuilder::plan_checkpointing(true) before \
+                     load() so the checkpointable classic Window+Aggregate path is used."
+                );
+            }
+        }
+
         let manager = crate::persistence::CheckpointManager::new(store, config)?;
 
         if let Some(cp) = manager.recover()? {

--- a/crates/varpulis-runtime/tests/checkpoint_tests.rs
+++ b/crates/varpulis-runtime/tests/checkpoint_tests.rs
@@ -624,3 +624,152 @@ fn test_pre_versioning_checkpoint_deserialization() {
     assert_eq!(cp.events_processed, 42);
     assert_eq!(cp.output_events_emitted, 10);
 }
+
+// =============================================================================
+// Audit C1 — fused columnar-aggregate ops silently drop windowed state on
+// checkpoint/restore. Fix: EngineBuilder::plan_checkpointing(true) un-fuses so
+// the checkpointable classic Window+Aggregate path is compiled instead.
+// =============================================================================
+
+fn c1_ts(ms: i64) -> chrono::DateTime<chrono::Utc> {
+    use chrono::TimeZone;
+    chrono::Utc.timestamp_millis_opt(ms).unwrap()
+}
+
+/// C1 fix, end-to-end: a `partition_by + tumbling window + sum` pipeline built
+/// with `plan_checkpointing(true)` snapshots its in-flight window state, and
+/// after a kill/restart the restored engine closes the window with the pre-crash
+/// events included in the aggregate.
+#[tokio::test]
+async fn checkpoint_planned_partition_window_survives_restart() {
+    let code = r"
+        event Reading:
+            device_id: str
+            temperature: float
+
+        stream DeviceAgg = Reading
+            .partition_by(device_id)
+            .window(1s)
+            .aggregate(total: sum(temperature))
+            .emit(total: total)
+    ";
+    let program = parse(code).expect("parse");
+
+    // --- Phase 1: fill a partial window on engine1, then checkpoint ---------
+    let (tx1, _rx1) = mpsc::channel::<Event>(1000);
+    let mut engine1 = Engine::builder()
+        .output(tx1)
+        .plan_checkpointing(true)
+        .build();
+    engine1.load(&program).expect("load");
+
+    // Window opens at t=100ms → [100ms, 1100ms). Three events land inside it;
+    // none crosses the boundary, so nothing emits yet.
+    for (t, temp) in [(100_i64, 10.0_f64), (200, 20.0), (300, 30.0)] {
+        engine1
+            .process(
+                Event::new("Reading")
+                    .with_timestamp(c1_ts(t))
+                    .with_field("device_id", "d1")
+                    .with_field("temperature", temp),
+            )
+            .await
+            .expect("process");
+    }
+
+    let cp = engine1.create_checkpoint();
+    // The un-fused classic Window op is what makes this state visible to the
+    // checkpoint. A fused engine would have no `DeviceAgg` window entry at all
+    // (see fused_partition_window_state_not_checkpointed below).
+    let wcp = cp
+        .window_states
+        .get("DeviceAgg")
+        .expect("plan_checkpointing must snapshot the window op's state");
+    let part = wcp
+        .partitions
+        .get("d1")
+        .expect("partition d1 must be snapshotted");
+    assert_eq!(
+        part.events.len(),
+        3,
+        "all three in-flight events must be captured; got {}",
+        part.events.len()
+    );
+
+    // --- Phase 2: kill engine1, restore into a fresh engine2, finish window --
+    let (tx2, mut rx2) = mpsc::channel::<Event>(1000);
+    let mut engine2 = Engine::builder()
+        .output(tx2)
+        .plan_checkpointing(true)
+        .build();
+    engine2.load(&program).expect("load");
+    engine2.restore_checkpoint(&cp).expect("restore");
+
+    // t=1200ms ≥ window_end(1100ms) closes [100,1100), emitting sum over the
+    // three restored events (10+20+30 = 60).
+    engine2
+        .process(
+            Event::new("Reading")
+                .with_timestamp(c1_ts(1200))
+                .with_field("device_id", "d1")
+                .with_field("temperature", 99.0_f64),
+        )
+        .await
+        .expect("process");
+
+    let out = rx2
+        .try_recv()
+        .expect("restored window must close and emit after the boundary event");
+    assert_eq!(
+        out.data.get("total"),
+        Some(&varpulis_core::Value::Float(60.0)),
+        "aggregate must include the pre-checkpoint events (10+20+30); got {:?}",
+        out.data.get("total")
+    );
+}
+
+/// Documents the contained C1 bug that `plan_checkpointing` works around: on the
+/// default (arrow) build WITHOUT planning, the pipeline fuses into
+/// `PartitionedWindowedColumnarAggregate`, whose windowed state is invisible to
+/// `create_checkpoint` — so the in-flight events are silently lost on restore.
+#[cfg(feature = "arrow")]
+#[tokio::test]
+async fn fused_partition_window_state_not_checkpointed() {
+    let code = r"
+        event Reading:
+            device_id: str
+            temperature: float
+
+        stream DeviceAgg = Reading
+            .partition_by(device_id)
+            .window(1s)
+            .aggregate(total: sum(temperature))
+            .emit(total: total)
+    ";
+    let program = parse(code).expect("parse");
+
+    // Default builder → no plan_checkpointing → columnar fusion kicks in.
+    let (tx, _rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    for (t, temp) in [(100_i64, 10.0_f64), (200, 20.0), (300, 30.0)] {
+        engine
+            .process(
+                Event::new("Reading")
+                    .with_timestamp(c1_ts(t))
+                    .with_field("device_id", "d1")
+                    .with_field("temperature", temp),
+            )
+            .await
+            .expect("process");
+    }
+
+    let cp = engine.create_checkpoint();
+    assert!(
+        !cp.window_states.contains_key("DeviceAgg"),
+        "fused columnar op state is NOT captured — this is the C1 bug that \
+         plan_checkpointing(true) avoids; got {:?}",
+        cp.window_states.get("DeviceAgg")
+    );
+}


### PR DESCRIPTION
## Audit finding C1 — checkpoint silently drops windowed aggregate state

The 2026-07-15 audit found that on the default (`arrow`) build, the fused
columnar-aggregate ops (`WindowedColumnarAggregate`,
`PartitionedWindowedColumnarAggregate`) keep their windowed state in a form that
`create_checkpoint` / `restore_checkpoint` never touch. Any `window + aggregate`
pipeline therefore **lost all in-flight window state across a checkpoint/restore**,
quietly breaking exactly-once recovery — the classic "wired but inert" failure
the audit was chartered to find.

## Fix — "un-fuse when checkpointing" (contained, correctness-first)

Fusion happens during `load()`, but `enable_checkpointing()` runs *after* load —
too late to change the compiled ops. So intent is declared up front:

- **`EngineBuilder::plan_checkpointing(true)`** sets a flag that gates the two
  fusion blocks in `compilation.rs`. With it set, the pipeline compiles to the
  classic `Window` + `Aggregate` ops whose state **is** checkpointed.
- The CLI wires this from `--checkpoint-dir` in both **`run`** and **`simulate`**.
- When checkpointing is off, fusion (and its throughput win) is **unchanged** — this
  only trades the columnar optimization for correctness when checkpointing is on.

Also in this PR:

- Real create/restore arms for **`PartitionedSlidingCountWindow`** — its
  per-partition buffers were silently dropped too (same family of bug).
- Explicit **no-op** arms for `Aggregate` / `PartitionedAggregate`, documenting
  that their running state lives in the upstream `Window` (not a catch-all miss).
- `enable_checkpointing()` now **warns loudly** if fused ops are present but
  `plan_checkpointing()` was never called, instead of losing state silently.

## Tests (fail-before / pass-after)

- `compilation`: `plan_checkpointing(true)` skips both partitioned and
  non-partitioned fusion, keeping the classic checkpointable ops (with a control
  assertion that the default build still fuses).
- `checkpoint_tests`: a `partition_by + tumbling(1s) + sum` pipeline **survives a
  kill/restart** — the three pre-crash events are included in the aggregate the
  restored engine emits when the window closes. A contrast test documents that the
  fused (default) engine drops the state — the exact bug `plan_checkpointing`
  avoids.

`make verify` green (fmt + clippy workspace/connectors + audit + deny).

## Deferred

Serializing the fused-bin state so checkpointing can keep the columnar perf path
is a perf-recovery optimization, deferred to the **Phase 6 exactly-once project**
per the remediation plan. Correctness is fully restored here without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vR5wHzbtcHxj5ZcdB4AP
