### PR TITLE
fix(engine): observe watermark + late-data on all dispatch paths (audit C2a)

### DIFF
--- a/crates/varpulis-runtime/src/engine/dispatch.rs
+++ b/crates/varpulis-runtime/src/engine/dispatch.rs
@@ -73,53 +73,11 @@ impl Engine {
             m.record_event(&event.event_type);
         }
 
-        // Check for late data against the watermark
-        if let Some(ref tracker) = self.watermark_tracker {
-            if let Some(effective_wm) = tracker.effective_watermark() {
-                if event.timestamp < effective_wm {
-                    // Event is behind the watermark — check allowed lateness per stream
-                    let mut allowed = false;
-                    if let Some(stream_names) = self.router.get_routes(&event.event_type) {
-                        for sn in stream_names.iter() {
-                            if let Some(cfg) = self.late_data_configs.get(sn) {
-                                if event.timestamp >= effective_wm - cfg.allowed_lateness {
-                                    allowed = true;
-                                    break;
-                                }
-                            }
-                        }
-                    }
-                    if !allowed && !self.late_data_configs.is_empty() {
-                        // Route to side-output if configured, otherwise drop
-                        let mut routed = false;
-                        if let Some(stream_names) = self.router.get_routes(&event.event_type) {
-                            for sn in stream_names.iter() {
-                                if let Some(cfg) = self.late_data_configs.get(sn) {
-                                    if let Some(ref side_stream) = cfg.side_output_stream {
-                                        debug!(
-                                            "Routing late event to side-output '{}' type={} ts={}",
-                                            side_stream, event.event_type, event.timestamp
-                                        );
-                                        // Create a late-data event with metadata
-                                        let mut late_event = (*event).clone();
-                                        late_event.event_type = side_stream.clone().into();
-                                        self.send_output(late_event);
-                                        routed = true;
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        if !routed {
-                            debug!(
-                                "Dropping late event type={} ts={} (watermark={})",
-                                event.event_type, event.timestamp, effective_wm
-                            );
-                        }
-                        return Ok(());
-                    }
-                }
-            }
+        // Watermark: late-data check + per-source observe, shared with the
+        // batch dispatch paths. Returns true when the event was consumed as
+        // late (dropped or routed to a side-output) and must not be dispatched.
+        if self.pre_dispatch_watermark(&event) {
+            return Ok(());
         }
 
         // Process events with depth limit to prevent infinite loops
@@ -127,19 +85,6 @@ impl Engine {
         let mut pending_events: VecDeque<(SharedEvent, usize)> =
             VecDeque::from([(event.clone(), 0)]);
         const MAX_CHAIN_DEPTH: usize = 10;
-
-        // Observe event in watermark tracker (after processing to not block)
-        if let Some(ref mut tracker) = self.watermark_tracker {
-            tracker.observe_event(&event.event_type, event.timestamp);
-
-            if let Some(new_wm) = tracker.effective_watermark() {
-                if self.last_applied_watermark.is_none_or(|last| new_wm > last) {
-                    self.last_applied_watermark = Some(new_wm);
-                    // Note: we don't call apply_watermark_to_windows here to avoid
-                    // double-mutable-borrow. The caller should periodically flush.
-                }
-            }
-        }
 
         // Process events iteratively, feeding output to dependent streams
         while let Some((current_event, depth)) = pending_events.pop_front() {
@@ -253,6 +198,84 @@ impl Engine {
         Ok(())
     }
 
+    /// Pre-dispatch watermark bookkeeping shared by every dispatch path.
+    ///
+    /// Returns `true` when the event is late and was consumed here — dropped, or
+    /// routed to a configured side-output — and therefore must NOT be dispatched
+    /// to streams. Fully synchronous so the sync `process_batch_sync` hot path
+    /// can call it too. Before this existed the late-data check + per-source
+    /// observe lived only in `process_inner`, so batch ingestion (the default
+    /// `run`/`simulate` paths) silently processed late events as on-time and
+    /// never advanced the watermark. In benchmark mode (no tracker) this is a
+    /// single `Option` branch per event.
+    fn pre_dispatch_watermark(&mut self, event: &SharedEvent) -> bool {
+        // 1. Late-data check against the CURRENT effective watermark.
+        if let Some(ref tracker) = self.watermark_tracker {
+            if let Some(effective_wm) = tracker.effective_watermark() {
+                if event.timestamp < effective_wm {
+                    // Event is behind the watermark — allowed only if some target
+                    // stream's configured lateness still covers it.
+                    let mut allowed = false;
+                    if let Some(stream_names) = self.router.get_routes(&event.event_type) {
+                        for sn in stream_names.iter() {
+                            if let Some(cfg) = self.late_data_configs.get(sn) {
+                                if event.timestamp >= effective_wm - cfg.allowed_lateness {
+                                    allowed = true;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                    if !allowed && !self.late_data_configs.is_empty() {
+                        // Route to side-output if configured, otherwise drop.
+                        let mut routed = false;
+                        if let Some(stream_names) = self.router.get_routes(&event.event_type) {
+                            for sn in stream_names.iter() {
+                                if let Some(cfg) = self.late_data_configs.get(sn) {
+                                    if let Some(ref side_stream) = cfg.side_output_stream {
+                                        debug!(
+                                            "Routing late event to side-output '{}' type={} ts={}",
+                                            side_stream, event.event_type, event.timestamp
+                                        );
+                                        let mut late_event = (**event).clone();
+                                        late_event.event_type = side_stream.clone().into();
+                                        self.send_output(late_event);
+                                        routed = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if !routed {
+                            debug!(
+                                "Dropping late event type={} ts={} (watermark={})",
+                                event.event_type, event.timestamp, effective_wm
+                            );
+                        }
+                        return true;
+                    }
+                }
+            }
+        }
+        // 2. Observe the event to advance per-source watermarks. The window
+        //    flush itself is a separate concern (event-time close is tracked in
+        //    a follow-up); here we only keep the watermark advancing correctly
+        //    across all ingestion paths.
+        if let Some(ref mut tracker) = self.watermark_tracker {
+            tracker.observe_event(&event.event_type, event.timestamp);
+        }
+        false
+    }
+
+    /// Effective event-time watermark across all sources, if watermark tracking
+    /// is enabled. Exposed for CLI/host loops and tests that need to observe
+    /// event-time progress.
+    pub fn effective_watermark(&self) -> Option<DateTime<Utc>> {
+        self.watermark_tracker
+            .as_ref()
+            .and_then(|t| t.effective_watermark())
+    }
+
     /// Process a batch of events for improved throughput (async-runtime only).
     ///
     /// Consecutive events with the same type (at the same chain depth) are
@@ -288,9 +311,15 @@ impl Engine {
         let mut pending_events: VecDeque<(SharedEvent, usize)> =
             VecDeque::with_capacity(batch_size + batch_size / 4);
 
-        // Convert all events to SharedEvents upfront
+        // Convert to SharedEvents; drop / side-output late events via the shared
+        // watermark pre-pass (previously only process_inner ran this, so batch
+        // ingestion ignored allowed_lateness / side-outputs entirely).
         for event in events {
-            pending_events.push_back((Arc::new(event), 0));
+            let shared = Arc::new(event);
+            if self.pre_dispatch_watermark(&shared) {
+                continue;
+            }
+            pending_events.push_back((shared, 0));
         }
 
         const MAX_CHAIN_DEPTH: usize = 10;
@@ -438,9 +467,15 @@ impl Engine {
         let mut pending_events: VecDeque<(SharedEvent, usize)> =
             VecDeque::with_capacity(batch_size + batch_size / 4);
 
-        // Convert all events to SharedEvents upfront
+        // Convert to SharedEvents; drop / side-output late events via the shared
+        // watermark pre-pass (previously only process_inner ran this, so batch
+        // ingestion ignored allowed_lateness / side-outputs entirely).
         for event in events {
-            pending_events.push_back((Arc::new(event), 0));
+            let shared = Arc::new(event);
+            if self.pre_dispatch_watermark(&shared) {
+                continue;
+            }
+            pending_events.push_back((shared, 0));
         }
 
         const MAX_CHAIN_DEPTH: usize = 10;
@@ -631,6 +666,9 @@ impl Engine {
             VecDeque::with_capacity(batch_size + batch_size / 4);
 
         for event in events {
+            if self.pre_dispatch_watermark(&event) {
+                continue;
+            }
             pending_events.push_back((event, 0));
         }
 

--- a/crates/varpulis-runtime/tests/watermark_tests.rs
+++ b/crates/varpulis-runtime/tests/watermark_tests.rs
@@ -6,7 +6,7 @@
 //! - Per-source watermark tracking integration with the engine
 //! - Watermark-triggered window closure
 
-use chrono::{Duration, Utc};
+use chrono::{Duration, TimeZone, Utc};
 use tokio::sync::mpsc;
 use varpulis_parser::parse;
 use varpulis_runtime::{Engine, Event};
@@ -127,4 +127,103 @@ async fn test_per_source_watermark_with_engine() {
             .with_timestamp(base_time + Duration::seconds(i));
         engine.process(event).await.expect("Failed to process");
     }
+}
+
+// =============================================================================
+// Audit C2a — watermark observation + late-data handling were wired ONLY into
+// the single-event `process_inner` path. The batch paths (process_batch /
+// process_batch_sync — the default `run`/`simulate` ingestion) silently skipped
+// them: late events were folded into windows as if on-time, and the watermark
+// never advanced under batch ingestion. Fix: a shared `pre_dispatch_watermark`
+// pre-pass runs on every dispatch path.
+// =============================================================================
+
+/// Fixed event-time clock (deterministic, no `Utc::now()`).
+fn c2_ts(secs: i64) -> chrono::DateTime<Utc> {
+    Utc.timestamp_opt(1_700_000_000 + secs, 0).unwrap()
+}
+
+#[test]
+fn late_event_via_process_batch_sync_is_dropped() {
+    // out_of_order:0 + allowed_lateness:0 → any event behind the watermark is
+    // dropped. Feeding a late event through the SYNC batch path must exclude it
+    // from the window aggregate. Before C2a the sync path never checked
+    // lateness, so the count came out 4 instead of 3.
+    let code = r"
+        stream Windowed = SensorEvent
+            .watermark(out_of_order: 0s)
+            .allowed_lateness(0s)
+            .window(10s)
+            .aggregate(n: count())
+            .emit(count: n)
+    ";
+    let program = parse(code).expect("parse");
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    let ev = |secs: i64, v: i64| {
+        Event::new("SensorEvent")
+            .with_field("value", v)
+            .with_timestamp(c2_ts(secs))
+    };
+    engine
+        .process_batch_sync(vec![
+            ev(1, 1),
+            ev(2, 2),
+            ev(3, 3),  // effective watermark now at t=3s
+            ev(1, 99), // LATE: t=1s < watermark, lateness 0 → must be dropped
+            ev(11, 4), // crosses the 10s boundary → closes window [1s, 11s)
+        ])
+        .expect("process");
+
+    let out = rx.try_recv().expect("window should close and emit");
+    assert_eq!(
+        out.data.get("count"),
+        Some(&varpulis_core::Value::Int(3)),
+        "late event must be excluded (would be 4 without the drop); got {:?}",
+        out.data.get("count")
+    );
+}
+
+#[test]
+fn effective_watermark_advances_via_batch_ingestion() {
+    // The batch paths now observe events into the watermark tracker, so the
+    // effective watermark advances under batch ingestion. Before C2a only the
+    // single-event process() path observed, so this accessor stayed None.
+    let code = r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .window(1m)
+            .aggregate(n: count())
+            .emit(count: n)
+    ";
+    let program = parse(code).expect("parse");
+    let (tx, _rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    assert!(
+        engine.effective_watermark().is_none(),
+        "no events observed yet → no watermark"
+    );
+
+    let ev = |secs: i64| {
+        Event::new("SensorEvent")
+            .with_field("value", 1_i64)
+            .with_timestamp(c2_ts(secs))
+    };
+    engine
+        .process_batch_sync(vec![ev(1), ev(2), ev(3)])
+        .expect("process");
+
+    assert!(
+        engine.effective_watermark().is_some(),
+        "batch ingestion must advance the effective watermark (was None before C2a)"
+    );
+    assert_eq!(
+        engine.effective_watermark(),
+        Some(c2_ts(3)),
+        "watermark should equal max observed ts (out_of_order 0)"
+    );
 }


### PR DESCRIPTION
## Audit C2a — unify watermark observation + late-data across all dispatch paths

The watermark late-data check and per-source observe were wired **only** into the
single-event `process_inner` path. The three batch paths — `process_batch`,
`process_batch_sync`, `process_batch_shared`, which are the default `run` /
`simulate` ingestion — skipped both. Under batch ingestion:

- late events were silently folded into windows as if on-time (corrupting
  aggregates whenever `allowed_lateness` / a side-output was configured), and
- the effective watermark never advanced at all.

Classic "wired but inert on the path that actually runs."

### Fix

Extract one synchronous `pre_dispatch_watermark(&SharedEvent) -> bool` pre-pass
(late-data drop / side-output routing + per-source observe) and call it from all
four dispatch paths. In benchmark mode (no tracker) it early-returns on a single
`Option` check, so the sync hot path pays only a predictable branch — the
`dispatch_benchmark` shape is unaffected. Adds a public `effective_watermark()`
accessor for host loops and tests.

### Scope — this is C2**a**

This unifies watermark **observation**; it does **not** change window-firing
behavior. The subtler half — actually closing event-time windows/sessions on
watermark advance, which means reconciling two firing models (`add_shared` fires
on event arrival vs `advance_watermark` fires on the watermark) without
double-emitting — is **C2b**, a focused follow-up. The existing watermark tests
only smoke-test "no crash" (e.g. `test_watermark_advance_triggers_window` asserts
nothing about the output), so that surface needs real per-window-type coverage,
which C2b will add. Splitting keeps the risky reconciliation out of a sweep.

### Tests (fail-before / pass-after)

Both were verified by neutralizing the shared helper and watching them go red
with the exact bug symptoms, then green when restored:

- `late_event_via_process_batch_sync_is_dropped` — a late event fed through the
  **sync** batch path is excluded from the window aggregate (count `3`; it was
  `4` before the drop).
- `effective_watermark_advances_via_batch_ingestion` — the watermark advances
  under batch ingestion (it stayed `None` before, because the path never
  observed).

`make verify` green (fmt + clippy workspace/connectors -D warnings + audit + deny).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0173vR5wHzbtcHxj5ZcdB4AP
