### PR TITLE
fix(cli): cap event-file reads so huge inputs fail fast instead of OOMing (Phase 2)

### DIFF
--- a/crates/varpulis-cli/src/commands/detect.rs
+++ b/crates/varpulis-cli/src/commands/detect.rs
@@ -310,7 +310,8 @@ pub async fn run_detect(
     println!();
 
     // Load events once (shared across all rule files)
-    let events_source = std::fs::read_to_string(events_path)?;
+    let events_source =
+        varpulis_cli::read_file_capped(events_path, varpulis_cli::MAX_INPUT_FILE_BYTES)?;
     let timed_events = EventFileParser::parse(&events_source)
         .map_err(|e| anyhow::anyhow!("Event file error: {e}"))?;
     let total_events = timed_events.len();

--- a/crates/varpulis-cli/src/commands/simulate.rs
+++ b/crates/varpulis-cli/src/commands/simulate.rs
@@ -231,7 +231,8 @@ pub async fn run_simulation(
 
     // Trace mode: process events one at a time and print trace entries after each
     if trace {
-        let events_source = std::fs::read_to_string(events_path)?;
+        let events_source =
+            varpulis_cli::read_file_capped(events_path, varpulis_cli::MAX_INPUT_FILE_BYTES)?;
         let events = EventFileParser::parse(&events_source)
             .map_err(|e| anyhow::anyhow!("Event file error: {e}"))?;
         let total_events = events.len();
@@ -256,7 +257,8 @@ pub async fn run_simulation(
         }
     } else if !timed && !streaming && num_workers > 1 {
         // Parallel preload mode (default with multiple workers)
-        let events_source = std::fs::read_to_string(events_path)?;
+        let events_source =
+            varpulis_cli::read_file_capped(events_path, varpulis_cli::MAX_INPUT_FILE_BYTES)?;
         let events = EventFileParser::parse(&events_source)
             .map_err(|e| anyhow::anyhow!("Event file error: {e}"))?;
         let total_events = events.len();
@@ -384,7 +386,8 @@ pub async fn run_simulation(
         }
     } else if !timed && !streaming {
         // Single-threaded preload mode (default)
-        let events_source = std::fs::read_to_string(events_path)?;
+        let events_source =
+            varpulis_cli::read_file_capped(events_path, varpulis_cli::MAX_INPUT_FILE_BYTES)?;
         let events = EventFileParser::parse(&events_source)
             .map_err(|e| anyhow::anyhow!("Event file error: {e}"))?;
         info!("Preloaded {} events from file", events.len());
@@ -684,7 +687,8 @@ pub async fn run_simulation(
         info!("Streamed {} events from file", event_reader.events_read());
     } else {
         // Timed mode (--timed) - replay events with real-time delays
-        let events_source = std::fs::read_to_string(events_path)?;
+        let events_source =
+            varpulis_cli::read_file_capped(events_path, varpulis_cli::MAX_INPUT_FILE_BYTES)?;
         let events = EventFileParser::parse(&events_source)
             .map_err(|e| anyhow::anyhow!("Event file error: {e}"))?;
         info!("Loaded {} events from file (timed mode)", events.len());

--- a/crates/varpulis-cli/src/lib.rs
+++ b/crates/varpulis-cli/src/lib.rs
@@ -33,6 +33,32 @@ use anyhow::Result;
 use varpulis_core::ast::{Program, Stmt};
 use varpulis_parser::parse;
 
+/// Cap for files the file-based CLI commands read wholesale into memory.
+///
+/// Guards against a pathological multi-GB input — e.g. a raw Sysmon/EVTX export
+/// fed to `detect` — exhausting RAM before parsing even starts. 1 GiB is far
+/// above any real rule file or hand-authored event file.
+pub const MAX_INPUT_FILE_BYTES: u64 = 1 << 30;
+
+/// Read a whole file to a string, refusing inputs larger than `max_bytes` so an
+/// oversized file fails fast with a clear message instead of OOMing the process.
+pub fn read_file_capped(path: impl AsRef<std::path::Path>, max_bytes: u64) -> Result<String> {
+    let path = path.as_ref();
+    let meta = std::fs::metadata(path)
+        .map_err(|e| anyhow::anyhow!("cannot stat {}: {e}", path.display()))?;
+    if meta.len() > max_bytes {
+        anyhow::bail!(
+            "{} is {} bytes, over the {}-byte cap — stream or split it \
+             (raise MAX_INPUT_FILE_BYTES only if you have the RAM)",
+            path.display(),
+            meta.len(),
+            max_bytes
+        );
+    }
+    std::fs::read_to_string(path)
+        .map_err(|e| anyhow::anyhow!("cannot read {}: {e}", path.display()))
+}
+
 /// Parse and validate VPL source code
 pub fn check_syntax(source: &str) -> Result<()> {
     match parse(source) {
@@ -217,6 +243,24 @@ pub fn parse_duration_str(s: &str) -> Result<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn read_file_capped_rejects_oversized() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("events.evt");
+        std::fs::write(&path, b"0123456789").unwrap(); // 10 bytes
+
+        // Under the cap → reads normally.
+        assert_eq!(read_file_capped(&path, 100).unwrap(), "0123456789");
+
+        // Over the cap → fails fast instead of reading (before this guard the
+        // whole file was slurped via read_to_string regardless of size).
+        let err = read_file_capped(&path, 5).unwrap_err().to_string();
+        assert!(
+            err.contains("over the") && err.contains("cap"),
+            "expected a size-cap error, got: {err}"
+        );
+    }
 
     #[test]
     fn test_check_syntax_valid() {


### PR DESCRIPTION
## Phase 2 resource-safety — `detect`/`simulate` OOM on huge event files

Both commands slurp the entire event file via `std::fs::read_to_string(events_path)`
before parsing. A pathological input — e.g. a raw multi-GB Sysmon/EVTX export fed
to `detect` (a realistic security use case) — exhausts RAM and kills the process
before a single event is parsed.

### Fix
`varpulis_cli::read_file_capped(path, max)` (default cap 1 GiB via
`MAX_INPUT_FILE_BYTES`) stats the file first and refuses anything oversized with a
clear message. Routed the 5 event-file reads across `detect` + `simulate` through
it.

### Test (fail-before / pass-after)
Verified by neutralizing the cap check and watching the test fail, then pass when
restored: `read_file_capped_rejects_oversized` — an over-cap file returns a
size-cap error; an under-cap file reads normally.

`make verify` green. (First PR on the new tiered CI — should show only the fast gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)