### PR TITLE
fix(cli): cap concurrent WebSocket connections on the server (Phase 4)

### DIFF
--- a/crates/varpulis-cli/src/commands/server.rs
+++ b/crates/varpulis-cli/src/commands/server.rs
@@ -84,6 +84,8 @@ pub fn build_mtls_client_config(
 struct WsRouteState {
     server_state: Arc<RwLock<ServerState>>,
     broadcast_tx: Arc<tokio::sync::broadcast::Sender<String>>,
+    /// Caps concurrent WebSocket connections (resource-exhaustion guard).
+    ws_limiter: websocket::WsConnectionLimiter,
 }
 
 /// Shared state for server health/ready endpoints.
@@ -138,12 +140,26 @@ async fn ws_upgrade_handler(
         return rejection.into_response();
     }
 
+    // Reject the upgrade once the concurrent-connection cap is hit, so a flood
+    // of upgrades can't exhaust sockets/tasks/broadcast subscribers. The guard
+    // is moved into the connection task and frees the slot on disconnect.
+    let Some(conn_guard) = app.ws.ws_limiter.try_acquire() else {
+        return (
+            axum::http::StatusCode::SERVICE_UNAVAILABLE,
+            "too many WebSocket connections",
+        )
+            .into_response();
+    };
+
     let state = app.ws.server_state.clone();
     let broadcast_tx = app.ws.broadcast_tx.clone();
     let response = ws
         .max_frame_size(1024 * 1024)
         .max_message_size(1024 * 1024)
-        .on_upgrade(move |socket| websocket::handle_connection(socket, state, broadcast_tx));
+        .on_upgrade(move |socket| async move {
+            let _conn_guard = conn_guard;
+            websocket::handle_connection(socket, state, broadcast_tx).await;
+        });
     // Echo the varpulis-v1 subprotocol so the browser accepts the upgrade
     // when auth was provided via Sec-WebSocket-Protocol header.
     (
@@ -338,6 +354,7 @@ pub async fn run_server(
     let ws_state = Arc::new(WsRouteState {
         server_state: state.clone(),
         broadcast_tx: broadcast_tx.clone(),
+        ws_limiter: websocket::WsConnectionLimiter::new(websocket::MAX_WS_CONNECTIONS),
     });
 
     // Health/ready check state (shared via axum State)

--- a/crates/varpulis-cli/src/websocket.rs
+++ b/crates/varpulis-cli/src/websocket.rs
@@ -3,7 +3,7 @@
 //! Provides WebSocket server functionality for the VS Code extension and other clients.
 
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use axum::extract::ws::{Message, WebSocket};
@@ -17,6 +17,62 @@ use varpulis_runtime::engine::Engine;
 use varpulis_runtime::event::Event;
 
 use crate::security;
+
+/// Default ceiling on concurrent WebSocket connections per server process.
+pub const MAX_WS_CONNECTIONS: usize = 1024;
+
+/// Caps concurrent WebSocket connections to protect the process from floods.
+///
+/// A flood of upgrades would otherwise exhaust sockets, tasks, and broadcast
+/// subscribers. Cheap atomic counter; [`try_acquire`](Self::try_acquire) hands
+/// back a guard that frees the slot on drop, so the count always tracks live
+/// connections even on abnormal exit.
+#[derive(Clone, Debug)]
+pub struct WsConnectionLimiter {
+    count: Arc<AtomicUsize>,
+    max: usize,
+}
+
+impl WsConnectionLimiter {
+    pub fn new(max: usize) -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+            max,
+        }
+    }
+
+    /// Reserve a connection slot, or return `None` when the cap is already
+    /// reached (the caller should reject the upgrade). The returned guard
+    /// releases the slot when dropped.
+    pub fn try_acquire(&self) -> Option<WsConnectionGuard> {
+        let prev = self.count.fetch_add(1, Ordering::AcqRel);
+        if prev >= self.max {
+            self.count.fetch_sub(1, Ordering::AcqRel);
+            None
+        } else {
+            Some(WsConnectionGuard {
+                count: self.count.clone(),
+            })
+        }
+    }
+
+    /// Current number of live connections.
+    pub fn active(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+}
+
+/// Frees a WebSocket connection slot when dropped.
+#[derive(Debug)]
+pub struct WsConnectionGuard {
+    count: Arc<AtomicUsize>,
+}
+
+impl Drop for WsConnectionGuard {
+    fn drop(&mut self) {
+        self.count.fetch_sub(1, Ordering::AcqRel);
+    }
+}
 
 // =============================================================================
 // Relay Metrics
@@ -733,6 +789,27 @@ pub fn value_to_json(value: &varpulis_core::Value) -> serde_json::Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn ws_connection_limiter_caps_and_releases() {
+        let lim = WsConnectionLimiter::new(2);
+        let g1 = lim.try_acquire().expect("1st under cap");
+        let _g2 = lim.try_acquire().expect("2nd at cap");
+        assert_eq!(lim.active(), 2);
+        // 3rd over the cap → rejected, and the count is not left inflated.
+        assert!(
+            lim.try_acquire().is_none(),
+            "over-cap acquire must be rejected"
+        );
+        assert_eq!(lim.active(), 2);
+        // Dropping a guard (a disconnect) frees exactly one slot.
+        drop(g1);
+        assert_eq!(lim.active(), 1);
+        assert!(
+            lim.try_acquire().is_some(),
+            "slot must free up after a disconnect"
+        );
+    }
 
     // -------------------------------------------------------------------------
     // WsMessage serialization tests


### PR DESCRIPTION
## Phase 4 — unbounded WebSocket connections (resource-exhaustion DoS)

The server's `/ws` upgrade handler authenticated the request and bounded
frame/message size, but placed **no cap on concurrent connections**. A client
could open unlimited sockets and exhaust file descriptors, tasks, and broadcast
subscribers.

### Fix
`WsConnectionLimiter` — an atomic counter with an RAII guard. `ws_upgrade_handler`
reserves a slot after auth and returns **503** once `MAX_WS_CONNECTIONS` (1024) is
reached. The guard is moved into the connection task, so the slot frees on
disconnect (even abnormal exit).

### Test (fail-before / pass-after)
`ws_connection_limiter_caps_and_releases`: acquire up to the cap succeeds; the
next is rejected *without* inflating the count; a slot frees after a guard drop.
Verified by disabling the cap check (over-cap acquire then succeeds → test fails),
then restoring.

`make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)