### PR TITLE
fix(connector-http): redact api_key in HttpWebhookConfig Debug (Phase 3)

### DIFF
--- a/crates/varpulis-connector-http/src/lib.rs
+++ b/crates/varpulis-connector-http/src/lib.rs
@@ -142,7 +142,7 @@ impl SinkConnector for HttpSink {
 // =============================================================================
 
 /// HTTP webhook configuration
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
+#[derive(Clone, serde::Serialize, serde::Deserialize, schemars::JsonSchema)]
 pub struct HttpWebhookConfig {
     /// Port to listen on
     pub port: u16,
@@ -158,6 +158,23 @@ pub struct HttpWebhookConfig {
     pub event_path: String,
     /// Path for batch event endpoint
     pub batch_path: String,
+}
+
+/// Hand-written so the `api_key` never reaches logs / errors / panic output via
+/// `{:?}`. The derived Debug printed it in full. The Some/None distinction is
+/// preserved so it's still visible *whether* a key is configured.
+impl std::fmt::Debug for HttpWebhookConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HttpWebhookConfig")
+            .field("port", &self.port)
+            .field("bind_address", &self.bind_address)
+            .field("api_key", &self.api_key.as_ref().map(|_| "***REDACTED***"))
+            .field("rate_limit", &self.rate_limit)
+            .field("max_batch_size", &self.max_batch_size)
+            .field("event_path", &self.event_path)
+            .field("batch_path", &self.batch_path)
+            .finish()
+    }
 }
 
 impl Default for HttpWebhookConfig {
@@ -554,6 +571,23 @@ fn json_to_event_from_json(json: &serde_json::Value) -> Event {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn http_config_debug_redacts_api_key() {
+        let config = HttpWebhookConfig::default().with_api_key("secret-key-123");
+        let rendered = format!("{config:?}");
+        assert!(
+            !rendered.contains("secret-key-123"),
+            "api_key leaked in Debug: {rendered}"
+        );
+        assert!(
+            rendered.contains("***REDACTED***"),
+            "configured key should be masked"
+        );
+        // With no key, Debug shows None (not REDACTED) so it's clear none is set.
+        let no_key = format!("{:?}", HttpWebhookConfig::default());
+        assert!(no_key.contains("api_key: None"), "got: {no_key}");
+    }
 
     #[test]
     fn test_http_webhook_config_default() {


### PR DESCRIPTION
## Phase 3 — webhook api_key leaks into logs via Debug

`HttpWebhookConfig` derived `Debug` over a typed `api_key: Option<String>`, so any
`{:?}` (tracing, error, panic) printed the webhook auth key in full.

### Fix
Hand-written `Debug` renders `api_key` as `***REDACTED***` when set; `None` is
preserved so it's still visible *whether* a key is configured. Same pattern as
#178 (Kafka).

### Test (fail-before / pass-after)
`http_config_debug_redacts_api_key`: a config with a key renders no secret in
`{:?}` but shows `***REDACTED***`; a keyless config shows `api_key: None`. Verified
by un-redacting (the key then prints as `Some("secret-key-123")` → test fails),
then restoring.

`make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)