### PR TITLE
fix(engine): close time windows on watermark, not event arrival (audit C2b)

### DIFF
--- a/crates/varpulis-cli/src/commands/run.rs
+++ b/crates/varpulis-cli/src/commands/run.rs
@@ -422,6 +422,12 @@ pub async fn run_program(
                     // Without this, events processed since the last barrier
                     // would be lost (uncommitted transaction).
                     if orchestrator.is_none() {
+                        // Shutdown drain (C2b): graduate still-open
+                        // event-time windows so their results reach the
+                        // sinks before the final barrier commits.
+                        if let Err(e) = engine.flush_final_watermark().await {
+                            tracing::warn!("Watermark drain error: {}", e);
+                        }
                         checkpoint_id += 1;
                         barrier_commit_2pc(&mut engine, &registry, &bindings, checkpoint_id).await;
                     }

--- a/crates/varpulis-cli/src/commands/simulate.rs
+++ b/crates/varpulis-cli/src/commands/simulate.rs
@@ -372,6 +372,11 @@ pub async fn run_simulation(
                         return;
                     }
 
+                    // End-of-input drain for event-time windows (C2b).
+                    if let Err(e) = worker_engine.flush_final_watermark_sync() {
+                        eprintln!("Worker {worker_id}: Watermark drain error: {e}");
+                    }
+
                     let worker_metrics = worker_engine.metrics();
                     total_counter.fetch_add(worker_metrics.events_processed, Ordering::Relaxed);
                     output_counter
@@ -603,7 +608,11 @@ pub async fn run_simulation(
 
         // Collect final metrics from all worker engines
         for (i, engine_mutex) in worker_engines.iter().enumerate() {
-            let w_engine = engine_mutex.lock().unwrap_or_else(|e| e.into_inner());
+            let mut w_engine = engine_mutex.lock().unwrap_or_else(|e| e.into_inner());
+            // End-of-input drain for event-time windows (C2b).
+            if let Err(e) = w_engine.flush_final_watermark_sync() {
+                eprintln!("Worker {i}: Watermark drain error: {e}");
+            }
             let worker_metrics = w_engine.metrics();
             total_events_processed.fetch_add(worker_metrics.events_processed, Ordering::Relaxed);
             output_emitted_count.fetch_add(worker_metrics.output_events_emitted, Ordering::Relaxed);
@@ -721,6 +730,14 @@ pub async fn run_simulation(
             .await?
             .map_err(|e| anyhow::anyhow!("Player error: {e}"))?;
     }
+
+    // End-of-input drain (C2b): graduate any still-open event-time windows.
+    // Watermark-driven only — arrival-driven windows keep today's EOF
+    // behavior. No-op when the program declares no `.watermark()`.
+    engine
+        .flush_final_watermark()
+        .await
+        .map_err(|e| anyhow::anyhow!("Watermark drain error: {e}"))?;
 
     // Flush any remaining session windows after all events are processed
     if engine.has_session_windows() {

--- a/crates/varpulis-runtime/src/engine/compilation.rs
+++ b/crates/varpulis-runtime/src/engine/compilation.rs
@@ -428,6 +428,31 @@ impl Engine {
         let mut sequence_event_types: Vec<String> = Vec::new();
         let mut partition_key: Option<String> = None;
 
+        // C2b: a stream that declares `.watermark(...)` compiles its time
+        // windows in watermark-driven (event-time) mode — events are filed
+        // into bins by their own timestamp and a window emits only when the
+        // watermark passes its end, instead of firing on arrival. Tumbling
+        // and low-ratio sliding windows redirect to the binned implementation
+        // (tumbling = slide == window) so the arrival-driven window types are
+        // never touched on the default path. `VARPULIS_WATERMARK_WINDOWS=0`
+        // is a kill-switch that reverts windows to arrival-driven firing
+        // (the watermark itself is still observed).
+        let kill_switch = matches!(
+            std::env::var("VARPULIS_WATERMARK_WINDOWS").as_deref(),
+            Ok("0")
+        );
+        let watermark_driven =
+            !kill_switch && ops.iter().any(|op| matches!(op, StreamOp::Watermark(_)));
+        let allowed_lateness = ops
+            .iter()
+            .find_map(|op| match op {
+                StreamOp::AllowedLateness(Expr::Duration(ns)) => {
+                    Some(Duration::nanoseconds(*ns as i64))
+                }
+                _ => None,
+            })
+            .unwrap_or_else(Duration::zero);
+
         // For SASE+ pattern compilation
         let mut followed_by_clauses: Vec<varpulis_core::ast::FollowedByClause> = Vec::new();
         let mut negation_clauses: Vec<varpulis_core::ast::FollowedByClause> = Vec::new();
@@ -686,13 +711,19 @@ impl Engine {
                         };
                         let gap = Duration::nanoseconds(gap_ns as i64);
                         if let Some(ref key) = partition_key {
-                            runtime_ops.push(RuntimeOp::Window(WindowType::PartitionedSession(
-                                PartitionedSessionWindow::new(key.clone(), gap),
-                            )));
+                            let w = if watermark_driven {
+                                PartitionedSessionWindow::new_watermark_driven(key.clone(), gap)
+                            } else {
+                                PartitionedSessionWindow::new(key.clone(), gap)
+                            };
+                            runtime_ops.push(RuntimeOp::Window(WindowType::PartitionedSession(w)));
                         } else {
-                            runtime_ops.push(RuntimeOp::Window(WindowType::Session(
-                                SessionWindow::new(gap),
-                            )));
+                            let w = if watermark_driven {
+                                SessionWindow::new_watermark_driven(gap)
+                            } else {
+                                SessionWindow::new(gap)
+                            };
+                            runtime_ops.push(RuntimeOp::Window(WindowType::Session(w)));
                         }
                     } else {
                         // Check if this is a count-based or time-based window
@@ -737,7 +768,40 @@ impl Engine {
                             varpulis_core::ast::Expr::Duration(ns) => {
                                 // Time-based window
                                 let duration = Duration::nanoseconds(*ns as i64);
-                                if let Some(ref key) = partition_key {
+                                if watermark_driven {
+                                    // C2b: every time window on a watermark
+                                    // stream uses the binned event-time
+                                    // implementation (tumbling = slide ==
+                                    // window), regardless of the ratio gate.
+                                    let slide =
+                                        args.sliding.as_ref().map_or(duration, |s| match s {
+                                            varpulis_core::ast::Expr::Duration(ns) => {
+                                                Duration::nanoseconds(*ns as i64)
+                                            }
+                                            _ => Duration::nanoseconds(60_000_000_000),
+                                        });
+                                    let wt = if let Some(ref key) = partition_key {
+                                        WindowType::PartitionedBinnedSliding(
+                                            PartitionedBinnedSlidingWindow::new_watermark_driven(
+                                                key.clone(),
+                                                duration,
+                                                slide,
+                                                Vec::new(),
+                                                allowed_lateness,
+                                            ),
+                                        )
+                                    } else {
+                                        WindowType::BinnedSliding(
+                                            BinnedSlidingWindow::new_watermark_driven(
+                                                duration,
+                                                slide,
+                                                Vec::new(),
+                                                allowed_lateness,
+                                            ),
+                                        )
+                                    };
+                                    runtime_ops.push(RuntimeOp::Window(wt));
+                                } else if let Some(ref key) = partition_key {
                                     // Partitioned time-based window
                                     if let Some(sliding) = &args.sliding {
                                         let slide_ns = match sliding {
@@ -813,7 +877,29 @@ impl Engine {
                             _ => {
                                 // Default to 5 minute tumbling window
                                 let duration = Duration::nanoseconds(300_000_000_000);
-                                if let Some(ref key) = partition_key {
+                                if watermark_driven {
+                                    let wt = if let Some(ref key) = partition_key {
+                                        WindowType::PartitionedBinnedSliding(
+                                            PartitionedBinnedSlidingWindow::new_watermark_driven(
+                                                key.clone(),
+                                                duration,
+                                                duration,
+                                                Vec::new(),
+                                                allowed_lateness,
+                                            ),
+                                        )
+                                    } else {
+                                        WindowType::BinnedSliding(
+                                            BinnedSlidingWindow::new_watermark_driven(
+                                                duration,
+                                                duration,
+                                                Vec::new(),
+                                                allowed_lateness,
+                                            ),
+                                        )
+                                    };
+                                    runtime_ops.push(RuntimeOp::Window(wt));
+                                } else if let Some(ref key) = partition_key {
                                     runtime_ops.push(RuntimeOp::Window(
                                         WindowType::PartitionedTumbling(
                                             PartitionedTumblingWindow::new(key.clone(), duration),
@@ -856,9 +942,15 @@ impl Engine {
                         // Skip fusion when checkpointing is planned: the fused
                         // columnar op's per-bin state is not captured by
                         // checkpoint/restore, so we keep the classic
-                        // Window+Aggregate path (which is) instead.
+                        // Window+Aggregate path (which is) instead. Also skip
+                        // it on watermark streams (C2b): the fused op closes
+                        // bins on max-seen event time and would ignore
+                        // out_of_order/allowed_lateness entirely.
                         if let Some(ref key) = partition_key {
-                            if !self.checkpoint_planned && aggregator.supported_for_columnar() {
+                            if !self.checkpoint_planned
+                                && !watermark_driven
+                                && aggregator.supported_for_columnar()
+                            {
                                 if let Some(crate::engine::types::RuntimeOp::Window(
                                     crate::engine::types::WindowType::PartitionedTumbling(w),
                                 )) = runtime_ops.last()
@@ -895,8 +987,11 @@ impl Engine {
                     {
                         // Skip fusion when checkpointing is planned (see the
                         // partitioned case above) — keep the checkpointable
-                        // classic Window+Aggregate path.
+                        // classic Window+Aggregate path. Watermark streams
+                        // (C2b) never fuse either: the fused op is event-
+                        // arrival driven.
                         if !self.checkpoint_planned
+                            && !watermark_driven
                             && partition_key.is_none()
                             && aggregator.supported_for_columnar()
                         {
@@ -2771,5 +2866,218 @@ mod arrow_fusion_tests {
         let bin2 = &by_bin[&2000];
         assert_eq!(bin2["s"], Value::Float(999.0));
         assert_eq!(bin2["c"], Value::Int(1));
+    }
+}
+
+#[cfg(test)]
+mod c2b_watermark_compile_tests {
+    //! C2b — `.watermark()` streams must compile their time windows in
+    //! watermark-driven (event-time) mode, redirected onto the binned
+    //! implementation, while no-watermark streams keep the exact
+    //! arrival-driven window types they compile to today.
+
+    use std::sync::Mutex;
+
+    use super::super::types::{RuntimeOp, WindowType};
+    use crate::engine::Engine;
+
+    /// Serializes tests that read or write `VARPULIS_WATERMARK_WINDOWS`
+    /// (compilation reads it; the kill-switch test sets it).
+    static ENV_GUARD: Mutex<()> = Mutex::new(());
+
+    /// Compile `source` and return the first stream's first Window op type
+    /// as `(summary, is_binned_watermark_driven)`.
+    fn first_window(source: &str) -> Option<(String, bool)> {
+        let mut engine = Engine::builder().build();
+        let program =
+            varpulis_parser::parse(source).unwrap_or_else(|e| panic!("parse failed: {e:?}"));
+        engine
+            .load(&program)
+            .unwrap_or_else(|e| panic!("load failed: {e}"));
+        let stream_names = engine.stream_names();
+        let stream_name = stream_names.first().expect("at least one stream");
+        let stream = engine.streams.get(*stream_name).expect("stream registered");
+        stream.operations.iter().find_map(|op| {
+            if let RuntimeOp::Window(wt) = op {
+                let (name, wm) = match wt {
+                    WindowType::Tumbling(_) => ("Tumbling", false),
+                    WindowType::Sliding(_) => ("Sliding", false),
+                    WindowType::Count(_) => ("Count", false),
+                    WindowType::SlidingCount(_) => ("SlidingCount", false),
+                    WindowType::PartitionedTumbling(_) => ("PartitionedTumbling", false),
+                    WindowType::PartitionedSliding(_) => ("PartitionedSliding", false),
+                    WindowType::Session(w) => ("Session", w.is_watermark_driven()),
+                    WindowType::PartitionedSession(w) => {
+                        ("PartitionedSession", w.is_watermark_driven())
+                    }
+                    WindowType::BinnedSliding(w) => ("BinnedSliding", w.is_watermark_driven()),
+                    WindowType::PartitionedBinnedSliding(w) => {
+                        ("PartitionedBinnedSliding", w.is_watermark_driven())
+                    }
+                };
+                Some((name.to_string(), wm))
+            } else {
+                None
+            }
+        })
+    }
+
+    #[test]
+    fn watermark_tumbling_compiles_to_binned_event_time_window() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let with_wm = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 2s)
+                .window(1s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(
+            first_window(with_wm),
+            Some(("BinnedSliding".to_string(), true)),
+            "watermark stream must compile the tumbling window in binned event-time mode"
+        );
+
+        // Control uses window→emit (no aggregate) so the arrow feature's
+        // Window+Aggregate fusion doesn't consume the Window op we inspect.
+        let without_wm = r"
+            stream W = SensorEvent
+                .window(1s)
+                .emit(v: value)
+        ";
+        assert_eq!(
+            first_window(without_wm),
+            Some(("Tumbling".to_string(), false)),
+            "no-watermark stream must keep the arrival-driven Tumbling window"
+        );
+    }
+
+    #[test]
+    fn watermark_low_ratio_sliding_compiles_to_binned_event_time_window() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // ratio 2 < 10: compiles to the arrival-driven SlidingWindow today.
+        let with_wm = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 1s)
+                .window(2s, sliding: 1s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(
+            first_window(with_wm),
+            Some(("BinnedSliding".to_string(), true))
+        );
+
+        let without_wm = r"
+            stream W = SensorEvent
+                .window(2s, sliding: 1s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(
+            first_window(without_wm),
+            Some(("Sliding".to_string(), false)),
+            "no-watermark low-ratio sliding must keep the arrival-driven SlidingWindow"
+        );
+    }
+
+    #[test]
+    fn watermark_partitioned_and_session_windows_compile_event_time() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        let partitioned = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 1s)
+                .partition_by(device)
+                .window(1s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(
+            first_window(partitioned),
+            Some(("PartitionedBinnedSliding".to_string(), true))
+        );
+
+        let session = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 1s)
+                .window(session: 2s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(first_window(session), Some(("Session".to_string(), true)));
+
+        let session_no_wm = r"
+            stream W = SensorEvent
+                .window(session: 2s)
+                .aggregate(n: count())
+                .emit(n: n)
+        ";
+        assert_eq!(
+            first_window(session_no_wm),
+            Some(("Session".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn kill_switch_env_reverts_to_arrival_driven_windows() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("VARPULIS_WATERMARK_WINDOWS", "0");
+        // window→emit (no aggregate) so arrow fusion can't consume the
+        // reverted Tumbling op before we inspect it.
+        let source = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 2s)
+                .window(1s)
+                .emit(v: value)
+        ";
+        let result = first_window(source);
+        std::env::remove_var("VARPULIS_WATERMARK_WINDOWS");
+        assert_eq!(
+            result,
+            Some(("Tumbling".to_string(), false)),
+            "kill switch must revert watermark streams to arrival-driven windows"
+        );
+    }
+
+    #[cfg(feature = "arrow")]
+    #[test]
+    fn watermark_stream_never_compiles_the_fused_columnar_op() {
+        let _guard = ENV_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+        // Scenario-02 shape (which fuses today) plus `.watermark()` — the
+        // fused op is event-arrival driven and must not be used (C2b §8).
+        let source = r"
+            event Reading:
+                ts: int
+                device_id: str
+                temperature: float
+
+            stream DeviceAgg = Reading
+                .watermark(out_of_order: 2s)
+                .partition_by(device_id)
+                .window(1s)
+                .aggregate(s: sum(temperature))
+                .emit(device_id: device_id, s: s)
+        ";
+        let mut engine = Engine::builder().build();
+        let program = varpulis_parser::parse(source).expect("parse");
+        engine.load(&program).expect("load");
+        let stream_names = engine.stream_names();
+        let stream = engine
+            .streams
+            .get(*stream_names.first().expect("stream"))
+            .expect("stream registered");
+        let ops: Vec<&'static str> = stream
+            .operations
+            .iter()
+            .map(|op| op.summary_name())
+            .collect();
+        assert!(
+            !ops.iter().any(|n| n.contains("ColumnarAggregate")),
+            "watermark stream must not fuse into the watermark-blind columnar op; got {ops:?}"
+        );
+        assert!(
+            ops.contains(&"Window"),
+            "watermark stream keeps the classic Window+Aggregate path; got {ops:?}"
+        );
     }
 }

--- a/crates/varpulis-runtime/src/engine/dispatch.rs
+++ b/crates/varpulis-runtime/src/engine/dispatch.rs
@@ -13,9 +13,9 @@ use rustc_hash::FxHashMap;
 use tracing::debug;
 
 use super::trace::TraceEntry;
-#[cfg(feature = "async-runtime")]
-use super::types::WindowType;
-use super::types::{RuntimeOp, RuntimeSource, StreamDefinition, StreamProcessResult, UserFunction};
+use super::types::{
+    RuntimeOp, RuntimeSource, StreamDefinition, StreamProcessResult, UserFunction, WindowType,
+};
 use super::{evaluator, pipeline, Engine};
 use crate::event::{Event, SharedEvent};
 use crate::sequence::SequenceContext;
@@ -190,6 +190,10 @@ impl Engine {
             }
         }
 
+        // C2b: graduate any event-time windows the watermark passed while
+        // observing this event. No-op unless watermark tracking is enabled.
+        self.flush_watermark().await?;
+
         // Update active streams gauge
         if let Some(ref m) = self.metrics {
             m.set_stream_count(self.streams.len());
@@ -269,8 +273,9 @@ impl Engine {
 
     /// Effective event-time watermark across all sources, if watermark tracking
     /// is enabled. Exposed for CLI/host loops and tests that need to observe
-    /// event-time progress.
-    pub fn effective_watermark(&self) -> Option<DateTime<Utc>> {
+    /// event-time progress. (Fully-qualified return type: this method is also
+    /// part of the sync path, available without `async-runtime`.)
+    pub fn effective_watermark(&self) -> Option<chrono::DateTime<chrono::Utc>> {
         self.watermark_tracker
             .as_ref()
             .and_then(|t| t.effective_watermark())
@@ -444,6 +449,11 @@ impl Engine {
             m.set_stream_count(self.streams.len());
         }
 
+        // C2b: graduate any event-time windows the watermark passed during
+        // this batch. Once per batch — the watermark only advances from the
+        // observe calls made above. No-op unless watermark tracking is on.
+        self.flush_watermark().await?;
+
         Ok(())
     }
 
@@ -572,6 +582,10 @@ impl Engine {
         for emitted in &emitted_batch {
             self.send_output_shared(emitted);
         }
+
+        // C2b: graduate any event-time windows the watermark passed during
+        // this batch (sync sibling of the async batch-tail flush).
+        self.flush_watermark_sync()?;
 
         Ok(())
     }
@@ -747,6 +761,10 @@ impl Engine {
             }
             m.set_stream_count(self.streams.len());
         }
+
+        // C2b: graduate any event-time windows the watermark passed during
+        // this batch.
+        self.flush_watermark().await?;
 
         Ok(())
     }
@@ -1120,6 +1138,115 @@ impl Engine {
         .await
     }
 
+    /// Collect graduated-window emissions for the first `Window` op of a
+    /// stream at watermark `wm`.
+    ///
+    /// Each inner `Vec` is ONE window emission and runs through the
+    /// post-window pipeline separately, so a multi-window graduation (e.g.
+    /// the end-of-input drain) produces one aggregate per window instead of
+    /// merging them. Arrival-driven windows keep the pre-C2b single-shot
+    /// `advance_watermark` behavior verbatim (0 or 1 emission, partitioned
+    /// variants flattened into one).
+    ///
+    /// `only_watermark_driven` restricts the pass to C2b watermark-driven
+    /// windows — used by the final end-of-input drain, which must not close
+    /// arrival-driven windows (their partial buffers are dropped at EOF
+    /// today, and the drain must not change no-watermark behavior).
+    fn collect_watermark_emissions(
+        stream: &mut StreamDefinition,
+        wm: chrono::DateTime<chrono::Utc>,
+        only_watermark_driven: bool,
+    ) -> Option<(usize, Vec<Vec<SharedEvent>>)> {
+        let wm_ms = wm.timestamp_millis();
+        for (idx, op) in stream.operations.iter_mut().enumerate() {
+            if let RuntimeOp::Window(window) = op {
+                let emissions: Vec<Vec<SharedEvent>> = match window {
+                    // C2b event-time windows: drain every graduated window,
+                    // one emission per (window, partition).
+                    WindowType::BinnedSliding(w) if w.is_watermark_driven() => w
+                        .drain_watermark(wm_ms)
+                        .into_iter()
+                        .map(|(_, events)| events)
+                        .collect(),
+                    WindowType::PartitionedBinnedSliding(w) if w.is_watermark_driven() => w
+                        .drain_watermark(wm_ms)
+                        .into_iter()
+                        .map(|(_, _, events)| events)
+                        .collect(),
+                    WindowType::Session(w) if w.is_watermark_driven() => w
+                        .drain_watermark(wm)
+                        .into_iter()
+                        .map(|(_, events)| events)
+                        .collect(),
+                    WindowType::PartitionedSession(w) if w.is_watermark_driven() => w
+                        .drain_watermark(wm)
+                        .into_iter()
+                        .map(|(_, _, events)| events)
+                        .collect(),
+                    _ if only_watermark_driven => Vec::new(),
+                    // Arrival-driven windows: pre-C2b behavior, one flattened
+                    // emission (external-heartbeat path).
+                    WindowType::Tumbling(w) => w.advance_watermark(wm).into_iter().collect(),
+                    WindowType::Sliding(w) => w.advance_watermark(wm).into_iter().collect(),
+                    WindowType::Session(w) => w.advance_watermark(wm).into_iter().collect(),
+                    WindowType::PartitionedTumbling(w) => {
+                        let all: Vec<_> = w
+                            .advance_watermark(wm)
+                            .into_iter()
+                            .flat_map(|(_, e)| e)
+                            .collect();
+                        if all.is_empty() {
+                            Vec::new()
+                        } else {
+                            vec![all]
+                        }
+                    }
+                    WindowType::PartitionedSliding(w) => {
+                        let all: Vec<_> = w
+                            .advance_watermark(wm)
+                            .into_iter()
+                            .flat_map(|(_, e)| e)
+                            .collect();
+                        if all.is_empty() {
+                            Vec::new()
+                        } else {
+                            vec![all]
+                        }
+                    }
+                    WindowType::PartitionedSession(w) => {
+                        let all: Vec<_> = w
+                            .advance_watermark(wm)
+                            .into_iter()
+                            .flat_map(|(_, e)| e)
+                            .collect();
+                        if all.is_empty() {
+                            Vec::new()
+                        } else {
+                            vec![all]
+                        }
+                    }
+                    WindowType::BinnedSliding(w) => w.advance_watermark(wm).into_iter().collect(),
+                    WindowType::PartitionedBinnedSliding(w) => {
+                        let all: Vec<_> = w
+                            .advance_watermark(wm)
+                            .into_iter()
+                            .flat_map(|(_, e)| e)
+                            .collect();
+                        if all.is_empty() {
+                            Vec::new()
+                        } else {
+                            vec![all]
+                        }
+                    }
+                    _ => Vec::new(), // Count-based windows don't use watermarks
+                };
+
+                return (!emissions.is_empty()).then_some((idx, emissions));
+            }
+        }
+        None
+    }
+
     /// Apply a watermark advance to all windows (async-runtime only).
     #[cfg(feature = "async-runtime")]
     #[tracing::instrument(skip(self))]
@@ -1127,92 +1254,87 @@ impl Engine {
         &mut self,
         wm: DateTime<Utc>,
     ) -> Result<(), super::error::EngineError> {
+        self.apply_watermark_to_windows_inner(wm, false).await
+    }
+
+    /// Watermark advance across all streams; each graduated window's events
+    /// run through the post-window pipeline as their own pass (async-runtime
+    /// only). See [`Self::collect_watermark_emissions`] for
+    /// `only_watermark_driven`.
+    #[cfg(feature = "async-runtime")]
+    pub(super) async fn apply_watermark_to_windows_inner(
+        &mut self,
+        wm: DateTime<Utc>,
+        only_watermark_driven: bool,
+    ) -> Result<(), super::error::EngineError> {
         let stream_names: Vec<String> = self.streams.keys().cloned().collect();
 
         for stream_name in stream_names {
-            let (window_idx, expired) = {
+            let collected = {
                 let stream = self.streams.get_mut(&stream_name).unwrap();
-                let mut result = Vec::new();
-                let mut found_idx = None;
-
-                for (idx, op) in stream.operations.iter_mut().enumerate() {
-                    if let RuntimeOp::Window(window) = op {
-                        let events: Option<Vec<SharedEvent>> = match window {
-                            WindowType::Tumbling(w) => w.advance_watermark(wm),
-                            WindowType::Sliding(w) => w.advance_watermark(wm),
-                            WindowType::Session(w) => w.advance_watermark(wm),
-                            WindowType::PartitionedTumbling(w) => {
-                                let parts = w.advance_watermark(wm);
-                                let all: Vec<_> = parts.into_iter().flat_map(|(_, e)| e).collect();
-                                if all.is_empty() {
-                                    None
-                                } else {
-                                    Some(all)
-                                }
-                            }
-                            WindowType::PartitionedSliding(w) => {
-                                let parts = w.advance_watermark(wm);
-                                let all: Vec<_> = parts.into_iter().flat_map(|(_, e)| e).collect();
-                                if all.is_empty() {
-                                    None
-                                } else {
-                                    Some(all)
-                                }
-                            }
-                            WindowType::PartitionedSession(w) => {
-                                let parts = w.advance_watermark(wm);
-                                let all: Vec<_> = parts.into_iter().flat_map(|(_, e)| e).collect();
-                                if all.is_empty() {
-                                    None
-                                } else {
-                                    Some(all)
-                                }
-                            }
-                            WindowType::BinnedSliding(w) => w.advance_watermark(wm),
-                            WindowType::PartitionedBinnedSliding(w) => {
-                                let parts = w.advance_watermark(wm);
-                                let all: Vec<_> = parts.into_iter().flat_map(|(_, e)| e).collect();
-                                if all.is_empty() {
-                                    None
-                                } else {
-                                    Some(all)
-                                }
-                            }
-                            _ => None, // Count-based windows don't use watermarks
-                        };
-
-                        if let Some(evts) = events {
-                            result = evts;
-                            found_idx = Some(idx);
-                        }
-                        break;
-                    }
-                }
-                (found_idx, result)
+                Self::collect_watermark_emissions(stream, wm, only_watermark_driven)
             };
-
-            if expired.is_empty() {
+            let Some((window_idx, emissions)) = collected else {
                 continue;
-            }
-
-            let window_idx = match window_idx {
-                Some(idx) => idx,
-                None => continue,
             };
 
-            let result = Self::process_post_window(
-                self.streams.get_mut(&stream_name).unwrap(),
-                expired,
-                window_idx,
-                &self.functions,
-                self.sinks.cache(),
-            )
-            .await?;
+            for expired in emissions {
+                let result = Self::process_post_window(
+                    self.streams.get_mut(&stream_name).unwrap(),
+                    expired,
+                    window_idx,
+                    &self.functions,
+                    self.sinks.cache(),
+                )
+                .await?;
 
-            for emitted in &result.emitted_events {
-                self.output_events_emitted += 1;
-                let owned = (**emitted).clone();
-                self.send_output(owned);
+                for emitted in &result.emitted_events {
+                    self.output_events_emitted += 1;
+                    let owned = (**emitted).clone();
+                    self.send_output(owned);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Sync sibling of [`Self::apply_watermark_to_windows_inner`] for the
+    /// sync dispatch path (`process_batch_sync` and sync hosts). Runs the
+    /// post-window pipeline through `execute_pipeline_sync`, which skips
+    /// async-only ops (`.to()` / `.enrich()`) exactly like the rest of the
+    /// sync path.
+    pub(super) fn apply_watermark_to_windows_sync_inner(
+        &mut self,
+        wm: chrono::DateTime<chrono::Utc>,
+        only_watermark_driven: bool,
+    ) -> Result<(), super::error::EngineError> {
+        let stream_names: Vec<String> = self.streams.keys().cloned().collect();
+
+        for stream_name in stream_names {
+            let collected = {
+                let stream = self.streams.get_mut(&stream_name).unwrap();
+                Self::collect_watermark_emissions(stream, wm, only_watermark_driven)
+            };
+            let Some((window_idx, emissions)) = collected else {
+                continue;
+            };
+
+            for expired in emissions {
+                let result = pipeline::execute_pipeline_sync(
+                    self.streams.get_mut(&stream_name).unwrap(),
+                    expired,
+                    window_idx + 1,
+                    pipeline::SkipFlags::for_post_window(),
+                    &self.functions,
+                    false,
+                )?;
+
+                for emitted in &result.emitted_events {
+                    self.output_events_emitted += 1;
+                    let owned = (**emitted).clone();
+                    self.send_output(owned);
+                }
             }
         }
 

--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -2225,6 +2225,71 @@ impl Engine {
         Ok(())
     }
 
+    /// Graduate any windows the current event-derived watermark has passed
+    /// (C2b). Called at the tail of every async dispatch path; shares the
+    /// monotonic `last_applied_watermark` gate with
+    /// [`Self::advance_external_watermark`] so the two drivers compose
+    /// without double-firing. No-op when watermark tracking is off.
+    #[cfg(feature = "async-runtime")]
+    pub async fn flush_watermark(&mut self) -> Result<(), error::EngineError> {
+        let Some(wm) = self.effective_watermark() else {
+            return Ok(());
+        };
+        if self.last_applied_watermark.is_none_or(|last| wm > last) {
+            self.apply_watermark_to_windows(wm).await?;
+            self.last_applied_watermark = Some(wm);
+        }
+        Ok(())
+    }
+
+    /// Sync sibling of [`Self::flush_watermark`] for the sync dispatch path.
+    pub fn flush_watermark_sync(&mut self) -> Result<(), error::EngineError> {
+        let Some(wm) = self.effective_watermark() else {
+            return Ok(());
+        };
+        if self.last_applied_watermark.is_none_or(|last| wm > last) {
+            self.apply_watermark_to_windows_sync_inner(wm, false)?;
+            self.last_applied_watermark = Some(wm);
+        }
+        Ok(())
+    }
+
+    /// Final end-of-input drain (C2b): graduate ALL remaining watermark-driven
+    /// windows as if the watermark had advanced past every buffered event.
+    ///
+    /// Only C2b event-time windows are drained — arrival-driven windows keep
+    /// today's EOF behavior (partial buffers dropped). Neither the tracker
+    /// nor `last_applied_watermark` is advanced; this is issued exactly once
+    /// at end-of-input / shutdown, never mid-stream. No-op when watermark
+    /// tracking is off.
+    #[cfg(feature = "async-runtime")]
+    pub async fn flush_final_watermark(&mut self) -> Result<(), error::EngineError> {
+        if self.watermark_tracker.is_none() {
+            return Ok(());
+        }
+        self.apply_watermark_to_windows_inner(DateTime::<Utc>::MAX_UTC, true)
+            .await
+    }
+
+    /// Sync sibling of [`Self::flush_final_watermark`] for sync hosts.
+    pub fn flush_final_watermark_sync(&mut self) -> Result<(), error::EngineError> {
+        if self.watermark_tracker.is_none() {
+            return Ok(());
+        }
+        self.apply_watermark_to_windows_sync_inner(chrono::DateTime::<chrono::Utc>::MAX_UTC, true)
+    }
+
+    /// Set the side-output stream for a stream's late-data config.
+    ///
+    /// Beyond-lateness events routed there instead of being dropped. VPL
+    /// cannot populate this yet (a `.side_output()` clause is a tracked
+    /// follow-up); exposed so embedding hosts and tests can configure it.
+    pub fn set_late_data_side_output(&mut self, stream: &str, side_output: &str) {
+        if let Some(cfg) = self.late_data_configs.get_mut(stream) {
+            cfg.side_output_stream = Some(side_output.to_string());
+        }
+    }
+
     /// Check if two runtime sources are compatible for state preservation (used by reload).
     #[cfg(feature = "async-runtime")]
     fn sources_compatible(a: &RuntimeSource, b: &RuntimeSource) -> bool {

--- a/crates/varpulis-runtime/src/window.rs
+++ b/crates/varpulis-runtime/src/window.rs
@@ -456,6 +456,22 @@ pub struct SessionWindow {
     pub(crate) columnar: ColumnarBuffer,
     /// Last event time (pub(crate) for checkpoint access)
     pub(crate) last_event_time: Option<DateTime<Utc>>,
+    /// C2b event-time mode: sessions live in `open_sessions`, merge on
+    /// out-of-order arrivals, and close only when the watermark passes
+    /// `session_end + gap` (see [`Self::drain_watermark`]). `add_shared`
+    /// never self-fires in this mode.
+    watermark_driven: bool,
+    /// Open sessions, disjoint and sorted by start; consecutive sessions are
+    /// separated by more than `gap` (otherwise they merge).
+    open_sessions: Vec<OpenSession>,
+}
+
+/// One open event-time session (C2b watermark mode).
+#[derive(Debug)]
+struct OpenSession {
+    start: DateTime<Utc>,
+    end: DateTime<Utc>,
+    events: Vec<SharedEvent>,
 }
 
 impl SessionWindow {
@@ -464,12 +480,35 @@ impl SessionWindow {
             gap,
             columnar: ColumnarBuffer::new(),
             last_event_time: None,
+            watermark_driven: false,
+            open_sessions: Vec::new(),
         }
+    }
+
+    /// Create a session window in watermark-driven (event-time) mode.
+    ///
+    /// Out-of-order events extend or merge the correct session by their own
+    /// timestamp; a session closes only when the watermark passes
+    /// `session_end + gap`, never on arrival of a later event.
+    pub fn new_watermark_driven(gap: Duration) -> Self {
+        let mut w = Self::new(gap);
+        w.watermark_driven = true;
+        w
+    }
+
+    /// Whether this session window closes on watermark advance instead of
+    /// on arrival / wall clock.
+    pub const fn is_watermark_driven(&self) -> bool {
+        self.watermark_driven
     }
 
     /// Add a shared event to the session window.
     /// Returns the completed session if the gap was exceeded.
     pub fn add_shared(&mut self, event: SharedEvent) -> Option<Vec<SharedEvent>> {
+        if self.watermark_driven {
+            self.insert_event_time(event);
+            return None;
+        }
         let event_time = event.timestamp;
         if let Some(last_time) = self.last_event_time {
             if event_time - last_time > self.gap {
@@ -486,6 +525,74 @@ impl SessionWindow {
         None
     }
 
+    /// File an event into the open session set by its own timestamp,
+    /// merging sessions the event bridges (C2b event-time mode).
+    fn insert_event_time(&mut self, event: SharedEvent) {
+        let ts = event.timestamp;
+        // First session whose extended interval [start − gap, end + gap]
+        // can still reach `ts` from the left.
+        let idx = self
+            .open_sessions
+            .partition_point(|s| s.end + self.gap < ts);
+        if let Some(session) = self.open_sessions.get_mut(idx) {
+            if ts >= session.start - self.gap {
+                // Joins this session; extending the end may bridge into the
+                // following session(s).
+                if ts < session.start {
+                    session.start = ts;
+                }
+                if ts > session.end {
+                    session.end = ts;
+                }
+                session.events.push(event);
+                while idx + 1 < self.open_sessions.len()
+                    && self.open_sessions[idx + 1].start - self.open_sessions[idx].end <= self.gap
+                {
+                    let next = self.open_sessions.remove(idx + 1);
+                    let session = &mut self.open_sessions[idx];
+                    if next.end > session.end {
+                        session.end = next.end;
+                    }
+                    session.events.extend(next.events);
+                }
+                return;
+            }
+        }
+        // Standalone session between idx-1 and idx.
+        self.open_sessions.insert(
+            idx,
+            OpenSession {
+                start: ts,
+                end: ts,
+                events: vec![event],
+            },
+        );
+    }
+
+    /// Close every open session the watermark has passed (C2b event-time
+    /// mode): a session graduates when `wm ≥ session_end + gap`. Returns one
+    /// `(session_start_ms, events)` entry per closed session, in ascending
+    /// session-start order.
+    pub fn drain_watermark(&mut self, wm: DateTime<Utc>) -> Vec<(i64, Vec<SharedEvent>)> {
+        let mut out = Vec::new();
+        let gap = self.gap;
+        let mut i = 0;
+        while i < self.open_sessions.len() {
+            if wm >= self.open_sessions[i].end + gap {
+                let s = self.open_sessions.remove(i);
+                out.push((s.start.timestamp_millis(), s.events));
+            } else {
+                i += 1;
+            }
+        }
+        out
+    }
+
+    /// Whether any event-time sessions are still open (C2b watermark mode).
+    pub fn has_open_sessions(&self) -> bool {
+        !self.open_sessions.is_empty()
+    }
+
     /// Add an event (wraps in Arc).
     pub fn add(&mut self, event: Event) -> Option<Vec<Event>> {
         self.add_shared(Arc::new(event))
@@ -494,7 +601,14 @@ impl SessionWindow {
 
     /// Check if this session has expired (last event time + gap < now).
     /// Returns accumulated events if expired, None otherwise.
+    ///
+    /// Watermark-driven sessions close on event time, never on the wall
+    /// clock, so this sweep is a no-op for them (they graduate via
+    /// [`Self::drain_watermark`]).
     pub fn check_expired(&mut self, now: DateTime<Utc>) -> Option<Vec<SharedEvent>> {
+        if self.watermark_driven {
+            return None;
+        }
         if let Some(last) = self.last_event_time {
             if now - last > self.gap {
                 return Some(self.flush_shared());
@@ -511,6 +625,13 @@ impl SessionWindow {
     /// Flush all events as SharedEvent references.
     pub fn flush_shared(&mut self) -> Vec<SharedEvent> {
         self.last_event_time = None;
+        if self.watermark_driven {
+            let mut all: Vec<SharedEvent> = Vec::new();
+            for s in self.open_sessions.drain(..) {
+                all.extend(s.events);
+            }
+            return all;
+        }
         self.columnar.take_all()
     }
 
@@ -528,15 +649,28 @@ impl SessionWindow {
             .collect()
     }
 
+    /// Serialize the buffered events for a checkpoint — the open event-time
+    /// sessions in watermark mode, the single columnar buffer otherwise.
+    pub(crate) fn checkpoint_events(&self) -> Vec<SerializableEvent> {
+        if self.watermark_driven {
+            return self
+                .open_sessions
+                .iter()
+                .flat_map(|s| s.events.iter())
+                .map(|e| SerializableEvent::from(e.as_ref()))
+                .collect();
+        }
+        self.columnar
+            .events()
+            .iter()
+            .map(|e| SerializableEvent::from(e.as_ref()))
+            .collect()
+    }
+
     /// Create a checkpoint of the current session state.
     pub fn checkpoint(&self) -> WindowCheckpoint {
         WindowCheckpoint {
-            events: self
-                .columnar
-                .events()
-                .iter()
-                .map(|e| SerializableEvent::from(e.as_ref()))
-                .collect(),
+            events: self.checkpoint_events(),
             window_start_ms: self.last_event_time.map(|t| t.timestamp_millis()),
             last_emit_ms: None,
             partitions: std::collections::HashMap::new(),
@@ -545,6 +679,15 @@ impl SessionWindow {
 
     /// Restore session state from a checkpoint.
     pub fn restore(&mut self, cp: &WindowCheckpoint) {
+        if self.watermark_driven {
+            // Re-file each event through the event-time path; session
+            // intervals and merges are rebuilt from the timestamps.
+            self.open_sessions.clear();
+            for se in &cp.events {
+                self.insert_event_time(Arc::new(Event::from(se.clone())));
+            }
+            return;
+        }
         let events: Vec<SharedEvent> = cp
             .events
             .iter()
@@ -581,6 +724,9 @@ pub struct PartitionedSessionWindow {
     partition_key: String,
     gap: Duration,
     windows: FxHashMap<String, SessionWindow>,
+    /// C2b event-time mode: per-key sessions are created watermark-driven
+    /// and close only via [`Self::drain_watermark`].
+    watermark_driven: bool,
 }
 
 impl PartitionedSessionWindow {
@@ -589,7 +735,22 @@ impl PartitionedSessionWindow {
             partition_key,
             gap,
             windows: FxHashMap::default(),
+            watermark_driven: false,
         }
+    }
+
+    /// Create a partitioned session window in watermark-driven (event-time)
+    /// mode. See [`SessionWindow::new_watermark_driven`].
+    pub fn new_watermark_driven(partition_key: String, gap: Duration) -> Self {
+        let mut w = Self::new(partition_key, gap);
+        w.watermark_driven = true;
+        w
+    }
+
+    /// Whether per-key sessions close on watermark advance instead of on
+    /// arrival / wall clock.
+    pub const fn is_watermark_driven(&self) -> bool {
+        self.watermark_driven
     }
 
     /// Add a shared event to the appropriate partition session.
@@ -599,10 +760,15 @@ impl PartitionedSessionWindow {
             |v| v.to_partition_key().into_owned(),
         );
 
-        let window = self
-            .windows
-            .entry(key)
-            .or_insert_with(|| SessionWindow::new(self.gap));
+        let watermark_driven = self.watermark_driven;
+        let gap = self.gap;
+        let window = self.windows.entry(key).or_insert_with(|| {
+            if watermark_driven {
+                SessionWindow::new_watermark_driven(gap)
+            } else {
+                SessionWindow::new(gap)
+            }
+        });
 
         window.add_shared(event)
     }
@@ -616,7 +782,13 @@ impl PartitionedSessionWindow {
     /// Check all partitions for expired sessions.
     /// Returns a list of (partition_key, events) for each expired session,
     /// and removes those partitions from the map.
+    ///
+    /// Watermark-driven sessions close on event time, never on the wall
+    /// clock — this sweep is a no-op for them.
     pub fn check_expired(&mut self, now: DateTime<Utc>) -> Vec<(String, Vec<SharedEvent>)> {
+        if self.watermark_driven {
+            return Vec::new();
+        }
         let mut expired = Vec::with_capacity(self.windows.len());
         let mut to_remove = Vec::new();
         for (key, window) in &mut self.windows {
@@ -664,12 +836,7 @@ impl PartitionedSessionWindow {
                 (
                     key.clone(),
                     PartitionedWindowCheckpoint {
-                        events: window
-                            .columnar
-                            .events()
-                            .iter()
-                            .map(|e| SerializableEvent::from(e.as_ref()))
-                            .collect(),
+                        events: window.checkpoint_events(),
                         window_start_ms: window.last_event_time.map(|t| t.timestamp_millis()),
                     },
                 )
@@ -688,6 +855,14 @@ impl PartitionedSessionWindow {
     pub fn restore(&mut self, cp: &WindowCheckpoint) {
         self.windows.clear();
         for (key, pcp) in &cp.partitions {
+            if self.watermark_driven {
+                let mut window = SessionWindow::new_watermark_driven(self.gap);
+                for se in &pcp.events {
+                    window.insert_event_time(Arc::new(Event::from(se.clone())));
+                }
+                self.windows.insert(key.clone(), window);
+                continue;
+            }
             let mut window = SessionWindow::new(self.gap);
             let events: Vec<SharedEvent> = pcp
                 .events
@@ -718,6 +893,23 @@ impl PartitionedSessionWindow {
             self.windows.remove(&key);
         }
         expired
+    }
+
+    /// Close graduated event-time sessions across all partitions (C2b
+    /// watermark mode). Returns one `(session_start_ms, partition_key,
+    /// events)` entry per closed session, ordered by session start then key;
+    /// partitions with no remaining open sessions are removed.
+    pub fn drain_watermark(&mut self, wm: DateTime<Utc>) -> Vec<(i64, String, Vec<SharedEvent>)> {
+        let mut out = Vec::new();
+        for (key, window) in &mut self.windows {
+            for (start, events) in window.drain_watermark(wm) {
+                out.push((start, key.clone(), events));
+            }
+        }
+        self.windows
+            .retain(|_, w| w.has_open_sessions() || !w.is_watermark_driven());
+        out.sort_by(|a, b| (a.0, a.1.as_str()).cmp(&(b.0, b.1.as_str())));
+        out
     }
 }
 
@@ -1450,7 +1642,8 @@ pub struct BinnedSlidingWindow {
     bins: BTreeMap<i64, WindowBin>,
     /// Number of bins that fit in one window.
     bins_per_window: usize,
-    /// Last emitted bin boundary (milliseconds).
+    /// Last emitted bin boundary (milliseconds). In watermark-driven mode
+    /// this is the start of the last *finalized* grid window instead.
     last_emit_bin: Option<i64>,
     /// Fields to track for pre-aggregation.
     tracked_fields: Vec<String>,
@@ -1458,6 +1651,13 @@ pub struct BinnedSlidingWindow {
     slide_ms: i64,
     /// Window size in milliseconds (cached for hot path).
     window_ms: i64,
+    /// C2b event-time mode: when true, `add_shared` only buffers (never
+    /// self-fires) and emission/eviction happen exclusively in
+    /// [`Self::drain_watermark`] when the watermark passes a window end.
+    watermark_driven: bool,
+    /// C2b: how long bins stay resident past the watermark so
+    /// within-lateness events can still be admitted (milliseconds).
+    allowed_lateness_ms: i64,
 }
 
 impl BinnedSlidingWindow {
@@ -1483,7 +1683,32 @@ impl BinnedSlidingWindow {
             tracked_fields,
             slide_ms,
             window_ms,
+            watermark_driven: false,
+            allowed_lateness_ms: 0,
         }
+    }
+
+    /// Create a binned window in watermark-driven (event-time) mode.
+    ///
+    /// Events are filed into slide-grid bins by their own timestamp; grid
+    /// windows `[w, w + window)` emit only when the watermark passes
+    /// `w + window` (see [`Self::drain_watermark`]). A tumbling event-time
+    /// window is expressed as `slide_interval == window_size`.
+    pub fn new_watermark_driven(
+        window_size: Duration,
+        slide_interval: Duration,
+        tracked_fields: Vec<String>,
+        allowed_lateness: Duration,
+    ) -> Self {
+        let mut w = Self::new(window_size, slide_interval, tracked_fields);
+        w.watermark_driven = true;
+        w.allowed_lateness_ms = allowed_lateness.num_milliseconds().max(0);
+        w
+    }
+
+    /// Whether this window emits on watermark advance instead of on arrival.
+    pub const fn is_watermark_driven(&self) -> bool {
+        self.watermark_driven
     }
 
     /// Compute the bin key (start time in ms) for a given event timestamp.
@@ -1503,6 +1728,13 @@ impl BinnedSlidingWindow {
         // Insert into bin
         let bin = self.bins.entry(bin_key).or_insert_with(WindowBin::new);
         bin.add_event(&event, &self.tracked_fields);
+
+        // C2b watermark mode: buffer only. Firing here (on arrival) would
+        // mis-place out-of-order events; emission and eviction are driven
+        // exclusively by `drain_watermark`.
+        if self.watermark_driven {
+            return None;
+        }
 
         // Expire old bins
         let cutoff = bin_key - self.window_ms;
@@ -1637,6 +1869,83 @@ impl BinnedSlidingWindow {
             self.collect_events()
         })
     }
+
+    /// Drain every grid window whose end the watermark has passed (C2b
+    /// event-time mode).
+    ///
+    /// Windows are the slide-grid intervals `[w, w + window)` for `w` a
+    /// multiple of the slide. A window graduates when `w + window ≤ wm`;
+    /// graduated windows are returned in ascending window-start order, each
+    /// as its own `(window_start_ms, events)` entry so a downstream
+    /// aggregation runs once per window instead of merging simultaneous
+    /// graduations. Windows at or below the horizon are final even when
+    /// empty: a later within-lateness event may still be admitted into a
+    /// resident bin, but an already-graduated window is never re-emitted
+    /// (v1 semantics: accumulate and emit once; no retraction).
+    ///
+    /// Bins are evicted only once `bin_start + window < wm − allowed_lateness`,
+    /// keeping them resident through the lateness horizon.
+    pub fn drain_watermark(&mut self, wm_ms: i64) -> Vec<(i64, Vec<SharedEvent>)> {
+        let mut emissions = Vec::new();
+        let (w_ms, s_ms) = (self.window_ms, self.slide_ms);
+        let Some(emit_horizon) = wm_ms.checked_sub(w_ms) else {
+            return emissions;
+        };
+        // Largest final window start: every grid window at or below this has
+        // been passed by the watermark.
+        let grid_horizon = emit_horizon.div_euclid(s_ms) * s_ms;
+
+        if let Some(&min_bin) = self.bins.keys().next() {
+            // First candidate: the window after the last finalized one, or
+            // the earliest grid window overlapping the oldest bin.
+            let mut w = match self.last_emit_bin {
+                Some(last) => last + s_ms,
+                None => ((min_bin - w_ms).div_euclid(s_ms) + 1) * s_ms,
+            };
+            while w <= grid_horizon {
+                match self.bins.range(w..).next() {
+                    None => break,
+                    Some((&next_bin, _)) if next_bin >= w + w_ms => {
+                        // Empty stretch: jump to the first grid window that
+                        // overlaps the next occupied bin.
+                        let jump = ((next_bin - w_ms).div_euclid(s_ms) + 1) * s_ms;
+                        w = jump.max(w + s_ms);
+                    }
+                    Some(_) => {
+                        let end = w + w_ms;
+                        let mut events: Vec<SharedEvent> = Vec::new();
+                        for bin in self.bins.range(w..end).map(|(_, b)| b) {
+                            // The trailing bin may straddle the window end
+                            // when the window is not a multiple of the slide.
+                            events.extend(
+                                bin.events
+                                    .iter()
+                                    .filter(|e| e.timestamp.timestamp_millis() < end)
+                                    .map(Arc::clone),
+                            );
+                        }
+                        if !events.is_empty() {
+                            emissions.push((w, events));
+                        }
+                        w += s_ms;
+                    }
+                }
+            }
+        }
+
+        if self.last_emit_bin.is_none_or(|last| grid_horizon > last) {
+            self.last_emit_bin = Some(grid_horizon);
+        }
+
+        // Evict bins past the lateness horizon: bin_end < wm − lateness.
+        let evict_cutoff = wm_ms
+            .saturating_sub(self.allowed_lateness_ms)
+            .saturating_sub(w_ms);
+        let keep = self.bins.split_off(&evict_cutoff);
+        self.bins = keep;
+
+        emissions
+    }
 }
 
 /// A partitioned binned sliding window that maintains separate binned windows per partition key.
@@ -1647,6 +1956,11 @@ pub struct PartitionedBinnedSlidingWindow {
     slide_interval: Duration,
     tracked_fields: Vec<String>,
     windows: FxHashMap<String, BinnedSlidingWindow>,
+    /// C2b event-time mode: per-key windows are created watermark-driven and
+    /// emit only via [`Self::drain_watermark`].
+    watermark_driven: bool,
+    /// C2b: lateness slack forwarded to per-key windows.
+    allowed_lateness: Duration,
 }
 
 impl PartitionedBinnedSlidingWindow {
@@ -1662,6 +1976,47 @@ impl PartitionedBinnedSlidingWindow {
             slide_interval,
             tracked_fields,
             windows: FxHashMap::default(),
+            watermark_driven: false,
+            allowed_lateness: Duration::zero(),
+        }
+    }
+
+    /// Create a partitioned binned window in watermark-driven (event-time)
+    /// mode. See [`BinnedSlidingWindow::new_watermark_driven`].
+    pub fn new_watermark_driven(
+        partition_key: String,
+        window_size: Duration,
+        slide_interval: Duration,
+        tracked_fields: Vec<String>,
+        allowed_lateness: Duration,
+    ) -> Self {
+        let mut w = Self::new(partition_key, window_size, slide_interval, tracked_fields);
+        w.watermark_driven = true;
+        w.allowed_lateness = allowed_lateness;
+        w
+    }
+
+    /// Whether per-key windows emit on watermark advance instead of on arrival.
+    pub const fn is_watermark_driven(&self) -> bool {
+        self.watermark_driven
+    }
+
+    /// Construct a per-key inner window in the mode this partitioned window
+    /// was compiled in.
+    fn new_inner_window(&self) -> BinnedSlidingWindow {
+        if self.watermark_driven {
+            BinnedSlidingWindow::new_watermark_driven(
+                self.window_size,
+                self.slide_interval,
+                self.tracked_fields.clone(),
+                self.allowed_lateness,
+            )
+        } else {
+            BinnedSlidingWindow::new(
+                self.window_size,
+                self.slide_interval,
+                self.tracked_fields.clone(),
+            )
         }
     }
 
@@ -1672,15 +2027,13 @@ impl PartitionedBinnedSlidingWindow {
             |v| v.to_partition_key().into_owned(),
         );
 
-        let window = self.windows.entry(key).or_insert_with(|| {
-            BinnedSlidingWindow::new(
-                self.window_size,
-                self.slide_interval,
-                self.tracked_fields.clone(),
-            )
-        });
-
-        window.add_shared(event)
+        if let Some(window) = self.windows.get_mut(&key) {
+            return window.add_shared(event);
+        }
+        let mut window = self.new_inner_window();
+        let result = window.add_shared(event);
+        self.windows.insert(key, window);
+        result
     }
 
     /// Get all current events from all partitions.
@@ -1727,11 +2080,7 @@ impl PartitionedBinnedSlidingWindow {
     pub fn restore(&mut self, cp: &WindowCheckpoint) {
         self.windows.clear();
         for (key, pcp) in &cp.partitions {
-            let mut window = BinnedSlidingWindow::new(
-                self.window_size,
-                self.slide_interval,
-                self.tracked_fields.clone(),
-            );
+            let mut window = self.new_inner_window();
             window.last_emit_bin = pcp.window_start_ms;
 
             for se in &pcp.events {
@@ -1756,6 +2105,21 @@ impl PartitionedBinnedSlidingWindow {
             }
         }
         results
+    }
+
+    /// Drain graduated grid windows across all partitions (C2b event-time
+    /// mode). Returns one `(window_start_ms, partition_key, events)` entry
+    /// per graduated per-key window, ordered by window start then key so
+    /// output is deterministic.
+    pub fn drain_watermark(&mut self, wm_ms: i64) -> Vec<(i64, String, Vec<SharedEvent>)> {
+        let mut out = Vec::new();
+        for (key, window) in &mut self.windows {
+            for (start, events) in window.drain_watermark(wm_ms) {
+                out.push((start, key.clone(), events));
+            }
+        }
+        out.sort_by(|a, b| (a.0, a.1.as_str()).cmp(&(b.0, b.1.as_str())));
+        out
     }
 }
 
@@ -3026,5 +3390,262 @@ mod tests {
         restored.restore(&cp);
 
         assert_eq!(restored.current_all_shared().len(), 2);
+    }
+
+    // =========================================================================
+    // C2b — watermark-driven (event-time) window modes
+    // =========================================================================
+
+    /// Fixed epoch-aligned event-time base (multiple of every window size
+    /// used below, so grid windows land on round offsets).
+    const C2B_BASE_MS: i64 = 1_700_000_000_000;
+
+    fn c2b_event(offset_ms: i64) -> SharedEvent {
+        Arc::new(
+            Event::new("T")
+                .with_timestamp(DateTime::from_timestamp_millis(C2B_BASE_MS + offset_ms).unwrap())
+                .with_field("v", offset_ms),
+        )
+    }
+
+    /// Window starts relative to the base, extracted for compact asserts.
+    fn rel_starts(emissions: &[(i64, Vec<SharedEvent>)]) -> Vec<(i64, Vec<i64>)> {
+        emissions
+            .iter()
+            .map(|(start, events)| {
+                (
+                    start - C2B_BASE_MS,
+                    events
+                        .iter()
+                        .map(|e| e.timestamp.timestamp_millis() - C2B_BASE_MS)
+                        .collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn binned_wm_never_self_fires_and_files_out_of_order_by_timestamp() {
+        // Tumbling event-time window: slide == window == 1s.
+        let mut w = BinnedSlidingWindow::new_watermark_driven(
+            Duration::seconds(1),
+            Duration::seconds(1),
+            Vec::new(),
+            Duration::zero(),
+        );
+        // Arrival order 0, 1, 3, 2 — ts=2 arrives after ts=3 crossed its
+        // window boundary. In arrival-driven mode the window would already
+        // have fired; here nothing fires on add.
+        for off in [0, 1_000, 3_000, 2_000] {
+            assert!(
+                w.add_shared(c2b_event(off)).is_none(),
+                "must never self-fire"
+            );
+        }
+        // Watermark reaches 3s: windows [0,1), [1,2), [2,3) graduate; the
+        // out-of-order ts=2 event sits in ITS window [2,3), not a later one.
+        let drained = rel_starts(&w.drain_watermark(C2B_BASE_MS + 3_000));
+        assert_eq!(
+            drained,
+            vec![(0, vec![0]), (1_000, vec![1_000]), (2_000, vec![2_000]),]
+        );
+        // Final drain: the last window graduates too.
+        let drained = rel_starts(&w.drain_watermark(i64::MAX));
+        assert_eq!(drained, vec![(3_000, vec![3_000])]);
+    }
+
+    #[test]
+    fn binned_wm_sliding_emits_overlapping_grid_windows() {
+        // 2s window sliding by 1s (ratio < 10 — the shape that used to
+        // compile to the arrival-driven SlidingWindow).
+        let mut w = BinnedSlidingWindow::new_watermark_driven(
+            Duration::seconds(2),
+            Duration::seconds(1),
+            Vec::new(),
+            Duration::zero(),
+        );
+        for off in [500, 1_500, 3_500] {
+            assert!(w.add_shared(c2b_event(off)).is_none());
+        }
+        // wm = 3.5s → windows ending ≤ 3.5s: [-1,1), [0,2), [1,3).
+        let drained = rel_starts(&w.drain_watermark(C2B_BASE_MS + 3_500));
+        assert_eq!(
+            drained,
+            vec![
+                (-1_000, vec![500]),
+                (0, vec![500, 1_500]),
+                (1_000, vec![1_500]),
+            ]
+        );
+        // Everything else graduates on the final drain.
+        let drained = rel_starts(&w.drain_watermark(i64::MAX));
+        assert_eq!(drained, vec![(2_000, vec![3_500]), (3_000, vec![3_500])]);
+    }
+
+    #[test]
+    fn binned_wm_lateness_admits_into_resident_bin_but_never_reemits() {
+        let mut w = BinnedSlidingWindow::new_watermark_driven(
+            Duration::seconds(1),
+            Duration::seconds(1),
+            Vec::new(),
+            Duration::seconds(2),
+        );
+        w.add_shared(c2b_event(0));
+        w.add_shared(c2b_event(2_500));
+        // wm = 3s: [0,1) and [2,3) emit. Bin 0 stays resident (lateness 2s:
+        // evict only when bin_end 1s < wm − 2s).
+        let drained = rel_starts(&w.drain_watermark(C2B_BASE_MS + 3_000));
+        assert_eq!(drained, vec![(0, vec![0]), (2_000, vec![2_500])]);
+        assert_eq!(w.bin_count(), 2, "bins stay resident through lateness");
+        // A within-lateness event (ts=0.5 ≥ wm − 2s) is admitted into the
+        // resident bin — and its already-graduated window must NOT re-emit.
+        w.add_shared(c2b_event(500));
+        assert!(w.drain_watermark(C2B_BASE_MS + 3_000).is_empty());
+        assert!(
+            rel_starts(&w.drain_watermark(i64::MAX)).is_empty(),
+            "graduated windows never re-emit (v1: accumulate, emit once)"
+        );
+        // Advancing the watermark past the lateness horizon evicts the bins.
+        assert_eq!(w.bin_count(), 0, "final drain evicts everything");
+    }
+
+    #[test]
+    fn binned_wm_checkpoint_restore_roundtrip_preserves_drain() {
+        let make = || {
+            BinnedSlidingWindow::new_watermark_driven(
+                Duration::seconds(1),
+                Duration::seconds(1),
+                Vec::new(),
+                Duration::zero(),
+            )
+        };
+        let mut a = make();
+        for off in [0, 1_000, 3_000, 2_000] {
+            a.add_shared(c2b_event(off));
+        }
+        let mut b = make();
+        b.restore(&a.checkpoint());
+        assert_eq!(
+            rel_starts(&a.drain_watermark(i64::MAX)),
+            rel_starts(&b.drain_watermark(i64::MAX)),
+            "restored window must drain identically"
+        );
+    }
+
+    #[test]
+    fn partitioned_binned_wm_drains_ordered_by_window_then_key() {
+        let mut w = PartitionedBinnedSlidingWindow::new_watermark_driven(
+            "dev".to_string(),
+            Duration::seconds(1),
+            Duration::seconds(1),
+            Vec::new(),
+            Duration::zero(),
+        );
+        for (off, dev) in [(0, "b"), (0, "a"), (1_200, "a")] {
+            let e = Event::new("T")
+                .with_timestamp(DateTime::from_timestamp_millis(C2B_BASE_MS + off).unwrap())
+                .with_field("dev", varpulis_core::Value::Str(dev.into()));
+            assert!(w.add_shared(Arc::new(e)).is_none());
+        }
+        let drained: Vec<(i64, String, usize)> = w
+            .drain_watermark(i64::MAX)
+            .into_iter()
+            .map(|(start, key, events)| (start - C2B_BASE_MS, key, events.len()))
+            .collect();
+        assert_eq!(
+            drained,
+            vec![
+                (0, "a".to_string(), 1),
+                (0, "b".to_string(), 1),
+                (1_000, "a".to_string(), 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn session_wm_out_of_order_arrival_builds_correct_sessions() {
+        // gap 1.5s; arrival order 0, 5, 1, 3 (event-time seconds). The
+        // arrival-driven session would close {0} on seeing 5 and then absorb
+        // 1 into the {5} session. Event-time sessions must come out as
+        // {0,1}, {3}, {5}.
+        let mut w = SessionWindow::new_watermark_driven(Duration::milliseconds(1_500));
+        for off in [0, 5_000, 1_000, 3_000] {
+            assert!(
+                w.add_shared(c2b_event(off)).is_none(),
+                "must never self-fire"
+            );
+        }
+        let drained = rel_starts(&w.drain_watermark(DateTime::<Utc>::MAX_UTC));
+        assert_eq!(
+            drained,
+            vec![
+                (0, vec![0, 1_000]),
+                (3_000, vec![3_000]),
+                (5_000, vec![5_000]),
+            ]
+        );
+    }
+
+    #[test]
+    fn session_wm_event_bridges_and_merges_two_sessions() {
+        let mut w = SessionWindow::new_watermark_driven(Duration::milliseconds(1_500));
+        w.add_shared(c2b_event(0));
+        w.add_shared(c2b_event(3_000));
+        // ts=1.5s reaches {0} (1.5 − 0 ≤ gap) and bridges to {3} (3 − 1.5 ≤ gap).
+        w.add_shared(c2b_event(1_500));
+        let drained = rel_starts(&w.drain_watermark(DateTime::<Utc>::MAX_UTC));
+        assert_eq!(drained.len(), 1, "bridged sessions must merge");
+        let mut members = drained[0].1.clone();
+        members.sort_unstable();
+        assert_eq!((drained[0].0, members), (0, vec![0, 1_500, 3_000]));
+    }
+
+    #[test]
+    fn session_wm_closes_only_when_watermark_passes_end_plus_gap() {
+        let mut w = SessionWindow::new_watermark_driven(Duration::seconds(2));
+        w.add_shared(c2b_event(0));
+        w.add_shared(c2b_event(10_000));
+        // Wall-clock sweep must not touch event-time sessions.
+        assert!(w.check_expired(DateTime::<Utc>::MAX_UTC).is_none());
+        // wm = 5s closes {0} (0 + 2s ≤ 5s) but not {10}.
+        let drained = rel_starts(
+            &w.drain_watermark(DateTime::from_timestamp_millis(C2B_BASE_MS + 5_000).unwrap()),
+        );
+        assert_eq!(drained, vec![(0, vec![0])]);
+        // wm = 12s closes {10}.
+        let drained = rel_starts(
+            &w.drain_watermark(DateTime::from_timestamp_millis(C2B_BASE_MS + 12_000).unwrap()),
+        );
+        assert_eq!(drained, vec![(10_000, vec![10_000])]);
+    }
+
+    #[test]
+    fn session_wm_checkpoint_restore_rebuilds_sessions() {
+        let mut a = SessionWindow::new_watermark_driven(Duration::milliseconds(1_500));
+        for off in [0, 5_000, 1_000, 3_000] {
+            a.add_shared(c2b_event(off));
+        }
+        let mut b = SessionWindow::new_watermark_driven(Duration::milliseconds(1_500));
+        b.restore(&a.checkpoint());
+        let wm = DateTime::<Utc>::MAX_UTC;
+        assert_eq!(
+            rel_starts(&a.drain_watermark(wm)),
+            rel_starts(&b.drain_watermark(wm)),
+            "restored session window must drain identically"
+        );
+    }
+
+    #[test]
+    fn partitioned_session_wm_wall_clock_sweep_is_noop() {
+        let mut w =
+            PartitionedSessionWindow::new_watermark_driven("dev".to_string(), Duration::seconds(1));
+        let e = Event::new("T")
+            .with_timestamp(DateTime::from_timestamp_millis(C2B_BASE_MS).unwrap())
+            .with_field("dev", varpulis_core::Value::Str("a".into()));
+        assert!(w.add_shared(Arc::new(e)).is_none());
+        assert!(w.check_expired(DateTime::<Utc>::MAX_UTC).is_empty());
+        let drained = w.drain_watermark(DateTime::<Utc>::MAX_UTC);
+        assert_eq!(drained.len(), 1);
+        assert_eq!(drained[0].1, "a");
     }
 }

--- a/crates/varpulis-runtime/tests/event_time_core.rs
+++ b/crates/varpulis-runtime/tests/event_time_core.rs
@@ -1,0 +1,293 @@
+//! Audit C2b — core event-time windowing semantics.
+//!
+//! Before C2b, time windows fired on EVENT ARRIVAL (`add_shared` emitted the
+//! moment an event's timestamp crossed the window boundary), so
+//! `.watermark(out_of_order: D)` was inert for windowing: an out-of-order
+//! event whose window had "closed" one event ago was silently folded into
+//! the WRONG window, corrupting aggregates. With C2b, a `.watermark()`
+//! stream files events into bins by their own timestamp and a window closes
+//! only when the watermark (`max_seen − out_of_order`) passes its end.
+//!
+//! This file intentionally uses only APIs that exist pre-C2b (engine load,
+//! batch dispatch, output channel) so it can be run against the old code to
+//! demonstrate fail-before/pass-after:
+//! - the `oo_*` and `closes_on_watermark_*` tests FAIL on pre-C2b code;
+//! - the `regression_guard_*` tests PASS unchanged on both (N1: zero change
+//!   without `.watermark()`).
+
+use chrono::{DateTime, Utc};
+use tokio::sync::mpsc;
+use varpulis_parser::parse;
+use varpulis_runtime::{Engine, Event};
+
+/// Epoch-aligned event-time base (multiple of 1s and 10s window grids).
+const BASE_MS: i64 = 1_700_000_000_000;
+
+fn ts(offset_ms: i64) -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(BASE_MS + offset_ms).unwrap()
+}
+
+fn ev(offset_ms: i64, value: i64) -> Event {
+    Event::new("SensorEvent")
+        .with_field("value", value)
+        .with_timestamp(ts(offset_ms))
+}
+
+fn engine_with(code: &str) -> (Engine, mpsc::Receiver<Event>) {
+    let program = parse(code).expect("parse");
+    let (tx, rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+    (engine, rx)
+}
+
+/// Numeric field extractor tolerant to Int/Float aggregation results.
+fn num(event: &Event, field: &str) -> i64 {
+    match event.data.get(field) {
+        Some(varpulis_core::Value::Int(i)) => *i,
+        Some(varpulis_core::Value::Float(f)) => *f as i64,
+        other => panic!("missing numeric field {field}: {other:?}"),
+    }
+}
+
+/// Drain the output channel into (count, sum) pairs.
+fn drain_n_s(rx: &mut mpsc::Receiver<Event>) -> Vec<(i64, i64)> {
+    let mut out = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        out.push((num(&e, "n"), num(&e, "s")));
+    }
+    out
+}
+
+const WM_TUMBLING: &str = r"
+    stream W = SensorEvent
+        .watermark(out_of_order: 2s)
+        .window(1s)
+        .aggregate(n: count(), s: sum(value))
+        .emit(n: n, s: s)
+";
+
+// =============================================================================
+// (a) Out-of-order event lands in its own (still-open) window
+// =============================================================================
+
+/// Arrival order 0s, 1s, 3s, 2s with out_of_order=2s and a 1s window: the
+/// ts=2s event arrives AFTER ts=3s crossed its boundary, but the watermark
+/// (max−2s) has not passed 3s yet, so it must land in window [2s,3s).
+/// A trailing ts=10s event pushes the watermark to 8s, graduating all four
+/// windows. Pre-C2b the window fired on arrival: ts=2s was folded in with
+/// ts=3s and the output was (1,1),(1,2),(2,7).
+#[test]
+fn oo_event_lands_in_correct_window_sync() {
+    let (mut engine, mut rx) = engine_with(WM_TUMBLING);
+    engine
+        .process_batch_sync(vec![
+            ev(0, 1),
+            ev(1_000, 2),
+            ev(3_000, 4),
+            ev(2_000, 3), // out-of-order: belongs to [2s,3s)
+            ev(10_000, 99),
+        ])
+        .expect("process");
+
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 1), (1, 2), (1, 3), (1, 4)],
+        "each 1s window must contain exactly its own event; the out-of-order \
+         ts=2s event must NOT be folded into a later window"
+    );
+}
+
+/// Same as [`oo_event_lands_in_correct_window_sync`] through the async batch
+/// path.
+#[tokio::test]
+async fn oo_event_lands_in_correct_window_async() {
+    let (mut engine, mut rx) = engine_with(WM_TUMBLING);
+    engine
+        .process_batch(vec![
+            ev(0, 1),
+            ev(1_000, 2),
+            ev(3_000, 4),
+            ev(2_000, 3),
+            ev(10_000, 99),
+        ])
+        .await
+        .expect("process");
+
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 1), (1, 2), (1, 3), (1, 4)]);
+}
+
+// =============================================================================
+// (d) Window closes on watermark passage, not on event arrival
+// =============================================================================
+
+/// With out_of_order=2s, an event at ts=2.9s must NOT close window [0s,1s)
+/// (watermark = 0.9s < 1s). Only an event at ts=3.1s (watermark 1.1s) may.
+/// Pre-C2b the window fired the moment ts=2.9s crossed the 1s boundary.
+#[test]
+fn closes_on_watermark_not_arrival_sync() {
+    let (mut engine, mut rx) = engine_with(WM_TUMBLING);
+
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(2_900, 2)])
+        .expect("process");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        Vec::<(i64, i64)>::new(),
+        "watermark 0.9s has not passed window end 1s — nothing may emit yet"
+    );
+
+    engine
+        .process_batch_sync(vec![ev(3_100, 3)])
+        .expect("process");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 1)],
+        "watermark 1.1s passed window end 1s — [0s,1s) must emit exactly once"
+    );
+}
+
+/// Same as [`closes_on_watermark_not_arrival_sync`] through the async path.
+#[tokio::test]
+async fn closes_on_watermark_not_arrival_async() {
+    let (mut engine, mut rx) = engine_with(WM_TUMBLING);
+
+    engine
+        .process_batch(vec![ev(0, 1), ev(2_900, 2)])
+        .await
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine
+        .process_batch(vec![ev(3_100, 3)])
+        .await
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 1)]);
+}
+
+// =============================================================================
+// (e) N1 regression guards — ZERO change when no `.watermark()` is declared
+// =============================================================================
+//
+// Golden outputs captured from pre-C2b `main`. These must stay byte-identical:
+// the arrival-driven window paths are structurally untouched by C2b.
+
+/// Tumbling+aggregate (the arrow feature fuses this shape into the streaming
+/// columnar op on default builds — golden reflects that path).
+#[test]
+fn regression_guard_tumbling_no_watermark() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![
+            ev(0, 1),
+            ev(1_000, 2),
+            ev(3_000, 4),
+            ev(2_000, 3),
+            ev(10_000, 99),
+        ])
+        .expect("process");
+
+    // NOTE: the fused columnar op advances its internal watermark to the
+    // running max event time and flushes per ingest, so the out-of-order
+    // ts=2s event (value 3) lands in an already-flushed bin and is DROPPED.
+    // That is pre-C2b behavior and stays untouched without `.watermark()` —
+    // declaring `.watermark(out_of_order: …)` is exactly what fixes it.
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 1), (1, 2), (1, 4)],
+        "no-watermark tumbling output must be identical to pre-C2b main"
+    );
+}
+
+/// Low-ratio sliding window (never fused; the classic arrival-driven
+/// SlidingWindow path).
+#[test]
+fn regression_guard_sliding_no_watermark() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .window(2s, sliding: 1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(500, 2), ev(1_500, 3), ev(3_000, 4)])
+        .expect("process");
+
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 1), (3, 6), (2, 7)],
+        "no-watermark sliding output must be identical to pre-C2b main"
+    );
+}
+
+/// Session window (arrival-driven gap close).
+#[test]
+fn regression_guard_session_no_watermark() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .window(session: 2s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(1_000, 2), ev(5_000, 4)])
+        .expect("process");
+
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 3)],
+        "no-watermark session output must be identical to pre-C2b main"
+    );
+}
+
+/// Partitioned tumbling+aggregate (fused on default builds).
+#[test]
+fn regression_guard_partitioned_tumbling_no_watermark() {
+    let program = parse(
+        r"
+        stream W = SensorEvent
+            .partition_by(dev)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    )
+    .expect("parse");
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    let pev = |off: i64, v: i64, dev: &str| {
+        Event::new("SensorEvent")
+            .with_field("value", v)
+            .with_field("dev", varpulis_core::Value::Str(dev.into()))
+            .with_timestamp(ts(off))
+    };
+    engine
+        .process_batch_sync(vec![
+            pev(0, 1, "a"),
+            pev(300, 2, "b"),
+            pev(600, 3, "a"),
+            pev(5_000, 99, "a"),
+        ])
+        .expect("process");
+
+    let mut got = drain_n_s(&mut rx);
+    got.sort_unstable();
+    assert_eq!(
+        got,
+        vec![(1, 2), (2, 4)],
+        "no-watermark partitioned tumbling output must be identical to pre-C2b main"
+    );
+}

--- a/crates/varpulis-runtime/tests/event_time_windows.rs
+++ b/crates/varpulis-runtime/tests/event_time_windows.rs
@@ -1,0 +1,647 @@
+//! Audit C2b — full event-time windowing matrix.
+//!
+//! Covers, per the C2b design: (b) late-within-lateness admission,
+//! (c) beyond-lateness drop / side-output routing, (f) end-of-input drain
+//! and idle-source heartbeat, (g) no double-emit, (h) multi-source
+//! min-watermark, (i) checkpoint/restore of binned mode, plus the sliding /
+//! session / partitioned window variants and (j) a property test asserting
+//! order-independence of emissions for events within `out_of_order`.
+//!
+//! (The fail-before/pass-after core cases (a)/(d)/(e) live in
+//! `event_time_core.rs`, which compiles against pre-C2b code.)
+
+use chrono::{DateTime, Utc};
+use proptest::prelude::*;
+use tokio::sync::mpsc;
+use varpulis_parser::parse;
+use varpulis_runtime::{Engine, Event};
+
+/// Epoch-aligned event-time base (multiple of 1s and 10s window grids).
+const BASE_MS: i64 = 1_700_000_000_000;
+
+fn ts(offset_ms: i64) -> DateTime<Utc> {
+    DateTime::from_timestamp_millis(BASE_MS + offset_ms).unwrap()
+}
+
+fn ev(offset_ms: i64, value: i64) -> Event {
+    Event::new("SensorEvent")
+        .with_field("value", value)
+        .with_timestamp(ts(offset_ms))
+}
+
+fn engine_with(code: &str) -> (Engine, mpsc::Receiver<Event>) {
+    let program = parse(code).expect("parse");
+    let (tx, rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+    (engine, rx)
+}
+
+fn num(event: &Event, field: &str) -> i64 {
+    match event.data.get(field) {
+        Some(varpulis_core::Value::Int(i)) => *i,
+        Some(varpulis_core::Value::Float(f)) => *f as i64,
+        other => panic!("missing numeric field {field}: {other:?}"),
+    }
+}
+
+fn drain_n_s(rx: &mut mpsc::Receiver<Event>) -> Vec<(i64, i64)> {
+    let mut out = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        out.push((num(&e, "n"), num(&e, "s")));
+    }
+    out
+}
+
+// =============================================================================
+// (b) Late-within-lateness: admitted to the resident bin, never re-emitted
+// =============================================================================
+
+#[test]
+fn late_within_lateness_admitted_but_window_not_reemitted() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .allowed_lateness(2s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+
+    // Watermark reaches 2s: window [0s,1s) graduates with two events.
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(500, 2), ev(2_000, 3)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), vec![(2, 3)]);
+
+    // ts=0.7s is behind the watermark (2s) but within allowed_lateness (2s):
+    // it passes the late-data gate and is admitted into the resident bin.
+    // v1 semantics: the already-graduated window is NOT re-emitted.
+    engine
+        .process_batch_sync(vec![ev(700, 50)])
+        .expect("process");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        Vec::<(i64, i64)>::new(),
+        "graduated windows never re-emit (v1: accumulate, emit once)"
+    );
+
+    // Later windows must not contain the late event either.
+    engine
+        .process_batch_sync(vec![ev(3_500, 4)])
+        .expect("process");
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 3), (1, 4)],
+        "the admitted-late value 50 must not leak into any later window"
+    );
+}
+
+// =============================================================================
+// (c) Beyond-lateness: dropped, or routed to the configured side-output
+// =============================================================================
+
+#[test]
+fn beyond_lateness_routed_to_side_output_within_lateness_admitted() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .allowed_lateness(1s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    // VPL cannot set the side-output stream yet (tracked follow-up) —
+    // configure it through the engine API, as the C2b design prescribes.
+    engine.set_late_data_side_output("W", "LateEvents");
+
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(2_000, 2)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 1)]);
+
+    // ts=0.5s < watermark(2s) − lateness(1s): beyond lateness → side-output.
+    engine
+        .process_batch_sync(vec![ev(500, 77)])
+        .expect("process");
+    let side: Vec<Event> = {
+        let mut out = Vec::new();
+        while let Ok(e) = rx.try_recv() {
+            out.push(e);
+        }
+        out
+    };
+    assert_eq!(
+        side.len(),
+        1,
+        "beyond-lateness event must reach the side-output"
+    );
+    assert_eq!(&*side[0].event_type, "LateEvents");
+    assert_eq!(num(&side[0], "value"), 77);
+
+    // ts=1.5s ≥ watermark − lateness: within lateness → admitted silently
+    // (its window [1s,2s) already graduated → no emission, no side-output).
+    engine
+        .process_batch_sync(vec![ev(1_500, 3)])
+        .expect("process");
+    assert!(
+        rx.try_recv().is_err(),
+        "within-lateness event must not side-output"
+    );
+
+    // The final drain shows neither late event contaminated a later window.
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 2)]);
+}
+
+// =============================================================================
+// (f) Bounded-stream drain and idle-source heartbeat
+// =============================================================================
+
+#[test]
+fn final_drain_graduates_open_windows_sync() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 2s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(500, 2)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 3)],
+        "end-of-input drain must graduate the still-open window"
+    );
+
+    // Idempotent: nothing left to drain.
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+}
+
+#[tokio::test]
+async fn final_drain_graduates_open_windows_async() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 2s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch(vec![ev(0, 1), ev(500, 2)])
+        .await
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine.flush_final_watermark().await.expect("drain");
+    assert_eq!(drain_n_s(&mut rx), vec![(2, 3)]);
+}
+
+/// An idle-source heartbeat (external watermark advance) must close a
+/// stalled window with no further events — the G4 case.
+#[tokio::test]
+async fn external_heartbeat_closes_stalled_window() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch(vec![ev(0, 1), ev(500, 2)])
+        .await
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine
+        .advance_external_watermark("SensorEvent", BASE_MS + 5_000)
+        .await
+        .expect("heartbeat");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 3)],
+        "idle-source heartbeat must graduate the stalled window"
+    );
+}
+
+// =============================================================================
+// (g) No double-emit across the arrival/watermark/final-drain drivers
+// =============================================================================
+
+#[test]
+fn no_double_emit_across_flush_drivers() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(1_000, 2)])
+        .expect("process");
+    // Redundant explicit flushes must not re-emit (monotonic gate).
+    engine.flush_watermark_sync().expect("flush");
+    engine.flush_watermark_sync().expect("flush");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 1)],
+        "[0s,1s) emits exactly once"
+    );
+
+    engine.flush_final_watermark_sync().expect("drain");
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(1, 2)],
+        "[1s,2s) emits exactly once"
+    );
+}
+
+// =============================================================================
+// (h) Multi-source min-watermark
+// =============================================================================
+
+/// Two watermarked sources: the effective watermark is the MIN across
+/// sources, so a fast source must not prematurely close windows a slow
+/// source still feeds.
+#[test]
+fn multi_source_min_watermark_gates_window_close() {
+    let program = parse(
+        r"
+        stream A = EvA
+            .watermark(out_of_order: 0s)
+            .window(1s)
+            .aggregate(na: count())
+            .emit(na: na)
+
+        stream B = EvB
+            .watermark(out_of_order: 0s)
+            .window(1s)
+            .aggregate(nb: count())
+            .emit(nb: nb)
+        ",
+    )
+    .expect("parse");
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    let eva = |off: i64| {
+        Event::new("EvA")
+            .with_field("value", 1i64)
+            .with_timestamp(ts(off))
+    };
+    let evb = |off: i64| {
+        Event::new("EvB")
+            .with_field("value", 1i64)
+            .with_timestamp(ts(off))
+    };
+
+    // EvA races ahead to 5s, EvB sits at 0.5s → effective watermark 0.5s:
+    // A's window [0s,1s) must NOT close yet.
+    engine
+        .process_batch_sync(vec![evb(500), eva(200), eva(800), eva(5_000)])
+        .expect("process");
+    assert!(
+        rx.try_recv().is_err(),
+        "effective watermark is min(5s, 0.5s) = 0.5s — no window may close"
+    );
+
+    // EvB advances to 2s → effective watermark 2s → both [0s,1s) windows close.
+    engine
+        .process_batch_sync(vec![evb(2_000)])
+        .expect("process");
+    let mut got: Vec<(String, i64)> = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        if let Some(v) = e.data.get("na") {
+            got.push(("na".into(), v.as_int().unwrap_or(-1)));
+        }
+        if let Some(v) = e.data.get("nb") {
+            got.push(("nb".into(), v.as_int().unwrap_or(-1)));
+        }
+    }
+    got.sort();
+    assert_eq!(
+        got,
+        vec![("na".to_string(), 2), ("nb".to_string(), 1)],
+        "min watermark passage must close both streams' [0s,1s) windows"
+    );
+}
+
+// =============================================================================
+// (i) Checkpoint/restore of binned event-time state
+// =============================================================================
+
+#[test]
+fn checkpoint_restore_mid_window_preserves_event_time_state() {
+    let code = r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 2s)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+    ";
+    let (mut engine1, mut rx1) = engine_with(code);
+    engine1
+        .process_batch_sync(vec![ev(0, 1), ev(1_000, 2)])
+        .expect("process");
+    assert_eq!(
+        drain_n_s(&mut rx1),
+        Vec::<(i64, i64)>::new(),
+        "nothing graduated yet"
+    );
+
+    // Snapshot mid-window, restore into a fresh engine.
+    let cp = engine1.create_checkpoint();
+    let (mut engine2, mut rx2) = engine_with(code);
+    engine2.restore_checkpoint(&cp).expect("restore");
+
+    // Feed the remainder to both engines; outputs must be identical.
+    for engine in [&mut engine1, &mut engine2] {
+        engine
+            .process_batch_sync(vec![ev(3_500, 3)])
+            .expect("process");
+        engine.flush_final_watermark_sync().expect("drain");
+    }
+    let out1 = drain_n_s(&mut rx1);
+    let out2 = drain_n_s(&mut rx2);
+    assert_eq!(out1, out2, "restored engine must emit identically");
+    assert_eq!(
+        out1,
+        vec![(1, 1), (1, 2), (1, 3)],
+        "each 1s window holds exactly its own event across the restore"
+    );
+}
+
+// =============================================================================
+// Sliding / session / partitioned event-time variants
+// =============================================================================
+
+/// Low-ratio sliding (redirected to the binned implementation when
+/// watermark-driven): overlapping 2s windows on a 1s grid.
+#[test]
+fn sliding_event_time_windows_overlap_correctly() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .window(2s, sliding: 1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(500, 1), ev(1_500, 2), ev(3_500, 3)])
+        .expect("process");
+    // wm=3.5s → windows [-1s,1s), [0s,2s), [1s,3s) graduate.
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 1), (2, 3), (1, 2)]);
+
+    engine.flush_final_watermark_sync().expect("drain");
+    // [2s,4s) and [3s,5s) both hold the ts=3.5s event.
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 3), (1, 3)]);
+}
+
+/// Event-time sessions: out-of-order arrivals build the correct session set
+/// (the arrival-driven session would mis-split and mis-merge these).
+#[test]
+fn session_event_time_out_of_order_sessions() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 10s)
+            .window(session: 1500ms)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    // Arrival order 0s, 5s, 1s, 3s — event-time sessions with gap 1.5s are
+    // {0s,1s}, {3s}, {5s}. out_of_order=10s keeps the watermark behind, so
+    // everything graduates on the final drain, in session-start order.
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(5_000, 2), ev(1_000, 3), ev(3_000, 4)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 4), (1, 4), (1, 2)],
+        "sessions must be {{0,1}}, {{3}}, {{5}} regardless of arrival order"
+    );
+}
+
+/// Event-time sessions close when the watermark passes end+gap, not on the
+/// arrival of a later event.
+#[test]
+fn session_event_time_closes_on_watermark() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 1s)
+            .window(session: 2s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    // ts=10s does NOT close session {0,1} on arrival; watermark is 9s which
+    // does pass 1s+2s → the session graduates in the same batch's flush.
+    engine
+        .process_batch_sync(vec![ev(0, 1), ev(1_000, 2)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), Vec::<(i64, i64)>::new());
+
+    engine
+        .process_batch_sync(vec![ev(10_000, 3)])
+        .expect("process");
+    assert_eq!(drain_n_s(&mut rx), vec![(2, 3)]);
+
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 3)]);
+}
+
+/// Partitioned event-time tumbling: per-key windows graduate separately and
+/// deterministically (window start, then key).
+#[test]
+fn partitioned_event_time_windows_graduate_per_key() {
+    let program = parse(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .partition_by(dev)
+            .window(1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    )
+    .expect("parse");
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    let pev = |off: i64, v: i64, dev: &str| {
+        Event::new("SensorEvent")
+            .with_field("value", v)
+            .with_field("dev", varpulis_core::Value::Str(dev.into()))
+            .with_timestamp(ts(off))
+    };
+    // Key "a" gets an out-of-order event (0.6s arrives after b's 0.3s and
+    // a's 5s would have closed an arrival-driven window).
+    engine
+        .process_batch_sync(vec![
+            pev(0, 1, "a"),
+            pev(300, 2, "b"),
+            pev(5_000, 99, "a"),
+            pev(600, 3, "a"),
+        ])
+        .expect("process");
+    // wm=5s → [0s,1s)×a (events 1,3 — including the out-of-order one) and
+    // [0s,1s)×b graduate, ordered (window, key).
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 4), (1, 2)],
+        "per-key windows must graduate separately, keyed by event time"
+    );
+
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(drain_n_s(&mut rx), vec![(1, 99)]);
+}
+
+/// Partitioned event-time sessions.
+#[test]
+fn partitioned_event_time_sessions() {
+    let program = parse(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 10s)
+            .partition_by(dev)
+            .window(session: 1s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    )
+    .expect("parse");
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    let pev = |off: i64, v: i64, dev: &str| {
+        Event::new("SensorEvent")
+            .with_field("value", v)
+            .with_field("dev", varpulis_core::Value::Str(dev.into()))
+            .with_timestamp(ts(off))
+    };
+    // a: {0, 0.5}, {3}; b: {0.2} — interleaved arrival, one out-of-order.
+    engine
+        .process_batch_sync(vec![
+            pev(0, 1, "a"),
+            pev(200, 2, "b"),
+            pev(3_000, 3, "a"),
+            pev(500, 4, "a"),
+        ])
+        .expect("process");
+    engine.flush_final_watermark_sync().expect("drain");
+    assert_eq!(
+        drain_n_s(&mut rx),
+        vec![(2, 5), (1, 2), (1, 3)],
+        "sessions ordered by (session start, key): a@0s, b@0.2s, a@3s"
+    );
+}
+
+/// High-ratio sliding (≥10, the shape that already compiled to the binned
+/// window): in watermark mode it emits grid windows, gated by the watermark.
+#[test]
+fn high_ratio_sliding_event_time_grid() {
+    let (mut engine, mut rx) = engine_with(
+        r"
+        stream W = SensorEvent
+            .watermark(out_of_order: 0s)
+            .window(20s, sliding: 2s)
+            .aggregate(n: count(), s: sum(value))
+            .emit(n: n, s: s)
+        ",
+    );
+    engine
+        .process_batch_sync(vec![ev(1_000, 1), ev(21_000, 2)])
+        .expect("process");
+    // wm=21s → the 10 grid windows [-18s,2s)…[0s,20s) (all containing ts=1s)
+    // graduate; every one holds exactly the ts=1s event.
+    let first = drain_n_s(&mut rx);
+    assert_eq!(first.len(), 10);
+    assert!(first.iter().all(|&e| e == (1, 1)));
+
+    engine.flush_final_watermark_sync().expect("drain");
+    // The 10 grid windows [2s,22s)…[20s,40s) hold only ts=21s (the events
+    // are exactly 20s apart, so no half-open 20s window contains both).
+    let rest = drain_n_s(&mut rx);
+    assert_eq!(rest.len(), 10);
+    assert!(rest.iter().all(|&e| e == (1, 2)));
+}
+
+// =============================================================================
+// (j) Property: emissions are order-independent within out_of_order
+// =============================================================================
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(32))]
+
+    /// For any event set whose arrival displacement is bounded by
+    /// `out_of_order`, the final window emissions equal those of the fully
+    /// sorted feed — the defining correctness property of event-time
+    /// windowing.
+    #[test]
+    fn emissions_are_arrival_order_independent(
+        base in proptest::collection::vec(0i64..10_000, 4..24),
+        deltas in proptest::collection::vec(-1_000i64..=1_000, 24),
+    ) {
+        // Sorted base arrival order, each timestamp perturbed by ±1s: the
+        // displacement vs. fully-sorted order is < 2s = out_of_order, so no
+        // event is ever late and no window may lose events.
+        let mut base = base;
+        base.sort_unstable();
+        let arrival: Vec<i64> = base
+            .iter()
+            .zip(&deltas)
+            .map(|(b, d)| b + d + 1_000)
+            .collect();
+        let mut sorted = arrival.clone();
+        sorted.sort_unstable();
+
+        let code = r"
+            stream W = SensorEvent
+                .watermark(out_of_order: 2s)
+                .window(1s)
+                .aggregate(n: count(), s: sum(value))
+                .emit(n: n, s: s)
+        ";
+        let run = |feed: &[i64]| -> Vec<(i64, i64)> {
+            let (mut engine, mut rx) = engine_with(code);
+            let events: Vec<Event> = feed.iter().map(|&off| ev(off, off)).collect();
+            engine.process_batch_sync(events).expect("process");
+            engine.flush_final_watermark_sync().expect("drain");
+            drain_n_s(&mut rx)
+        };
+
+        prop_assert_eq!(run(&arrival), run(&sorted));
+    }
+}


### PR DESCRIPTION
## Summary

Implements the C2b design (follow-up to C2a #171-era `516961b`): time windows on `.watermark()` streams now close when the **event-time watermark** (`max_seen − out_of_order`) passes the window end, instead of firing on event arrival. Out-of-order events are filed into their **correct** window by their own timestamp; `allowed_lateness` keeps bins resident for late admission; sessions merge on out-of-order arrivals and close on watermark passage.

**N1 hard constraint honored:** streams without `.watermark()` compile to the exact same arrival-driven window types as before — the redirect happens at compile time, so the default path is structurally untouched (goldens verified byte-identical against pre-C2b `main`).

## Approach (per design §9/§10 de-risking)

Instead of adding a watermark mode to every window type, the binned implementation carries the event-time mode and compilation redirects to it:

| Window on a `.watermark()` stream | Compiles to |
|---|---|
| `.window(D)` (tumbling) | `BinnedSliding(watermark_driven, slide == D)` |
| `.window(D, sliding: S)` (any ratio) | `BinnedSliding(watermark_driven)` |
| `.window(session: G)` | `Session(watermark_driven)` — multi-session, gap-merge |
| partitioned variants | partitioned equivalents, per-key |
| count windows | unchanged (N2) |
| arrow fused columnar aggregate | **fusion disabled** on watermark streams (N3, watermark-blind); classic Window+Aggregate used |

- `add_shared` never self-fires in watermark mode; `drain_watermark` emits each graduated grid window **separately** through the post-window pipeline (simultaneous graduations no longer merge into one aggregate), in deterministic (window start, key) order.
- `Engine::flush_watermark(_sync)` runs at the tail of **all four** dispatch paths, sharing the monotonic `last_applied_watermark` gate with `advance_external_watermark` → exactly one firing model per mode, no double-emit (§8).
- `Engine::flush_final_watermark(_sync)`: end-of-input drain (G4), wired into `simulate` (all worker modes) and `run` shutdown before the final 2PC barrier. Drains **only** watermark-driven windows.
- Wall-clock session sweep skips event-time sessions; idle-source heartbeat (`advance_external_watermark`) drains them correctly.
- Kill-switch: `VARPULIS_WATERMARK_WINDOWS=0` reverts to arrival firing (watermark still observed).
- `set_late_data_side_output()` exposes side-output routing (VPL `.side_output()` clause: tracked follow-up, §7.2).
- Bonus: `effective_watermark` no longer breaks the `--no-default-features` build (pre-existing C2a issue).

## Fail-before / pass-after

`tests/event_time_core.rs` compiles against pre-C2b code. Run against stashed `main`:

```
test closes_on_watermark_not_arrival_sync ... FAILED   ← C2b semantics
test closes_on_watermark_not_arrival_async ... FAILED
test oo_event_lands_in_correct_window_async ... FAILED
test oo_event_lands_in_correct_window_sync ... FAILED
test regression_guard_partitioned_tumbling_no_watermark ... ok   ← N1 goldens
test regression_guard_session_no_watermark ... ok
test regression_guard_sliding_no_watermark ... ok
test regression_guard_tumbling_no_watermark ... ok
```

On this branch: all 8 pass, plus the full §11 matrix in `tests/event_time_windows.rs` — (b) late-within-lateness admitted/never-re-emitted, (c) beyond-lateness drop + side-output, (f) EOF drain + idle heartbeat, (g) no double-emit, (h) multi-source min-watermark, (i) checkpoint/restore mid-window, sliding/session/partitioned/high-ratio variants, (j) proptest order-independence within `out_of_order`.

## Verification

- 2430 runtime tests pass, 0 failed (entire crate incl. all pre-existing window/watermark suites — no intentional semantic changes to any existing test)
- `make verify` green (fmt + clippy `-D warnings` + audit + deny)
- End-to-end via CLI: `varpulis simulate` with out-of-order `.evt` feed emits per-window aggregates correctly and drains open windows at EOF

## Follow-ups (design §10 step 5, not in this PR)

- VPL `.side_output("stream")` clause → populate `LateDataConfig.side_output_stream`
- Watermark-aware fused columnar aggregate (re-enable fusion on watermark streams)
- Retraction / re-emit semantics for post-graduation late events (N4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)