### PR TITLE
fix(engine): drain in-flight events before checkpoint snapshot (audit C3)

### DIFF
--- a/crates/varpulis-cli/src/commands/run.rs
+++ b/crates/varpulis-cli/src/commands/run.rs
@@ -183,6 +183,10 @@ pub async fn run_program(
         // the call. Must happen BEFORE start_source so the consumer task
         // picks up the shared handle on its first iteration.
         registry.set_engine_offsets_registry(engine.source_offsets_handle());
+        // Wire the cooperative source-pause flag so replayable sources stop
+        // pulling while the checkpoint barrier drains in-flight events (C3).
+        // Also before start_source, for the same reason.
+        registry.set_source_pause_handle(engine.source_pause_handle());
 
         // Start sources (connector-type-agnostic)
         for binding in &bindings {
@@ -363,8 +367,9 @@ pub async fn run_program(
                             // as a single checkpoint epoch.
                             checkpoint_id += 1;
                             let coordinator = RegistryCommitCoordinator { registry: &registry };
-                            if let Err(e) =
-                                engine.barrier_commit_2pc(checkpoint_id, &coordinator).await
+                            if let Err(e) = engine
+                                .barrier_commit_2pc(checkpoint_id, &mut event_rx, &coordinator)
+                                .await
                             {
                                 tracing::warn!(
                                     "Checkpoint barrier failed (epoch {checkpoint_id}): {e}"
@@ -390,7 +395,10 @@ pub async fn run_program(
                         }
                         checkpoint_id += 1;
                         let coordinator = RegistryCommitCoordinator { registry: &registry };
-                        if let Err(e) = engine.barrier_commit_2pc(checkpoint_id, &coordinator).await {
+                        if let Err(e) = engine
+                            .barrier_commit_2pc(checkpoint_id, &mut event_rx, &coordinator)
+                            .await
+                        {
                             tracing::warn!("Checkpoint barrier failed (epoch {checkpoint_id}): {e}");
                         }
                     }

--- a/crates/varpulis-connector-api/src/managed.rs
+++ b/crates/varpulis-connector-api/src/managed.rs
@@ -99,6 +99,13 @@ pub trait ManagedConnector: Send + Sync {
     /// connectors (MQTT, NATS) ignore this.
     fn set_engine_offsets_registry(&mut self, _registry: EngineOffsetRegistry) {}
 
+    /// Bind this connector to the engine's cooperative source-pause flag.
+    /// Replayable sources check it before each upstream poll and stop pulling
+    /// while it is set, so the checkpoint barrier can drain in-flight events and
+    /// snapshot a coherent (applied == committed) offset set. Non-replayable
+    /// connectors ignore it.
+    fn set_source_pause_handle(&mut self, _handle: std::sync::Arc<std::sync::atomic::AtomicBool>) {}
+
     /// Commit the given per-partition offsets back to the external system
     /// (e.g. Kafka consumer group coordinator) as part of a 2PC checkpoint
     /// commit. Default no-op for connectors without replayable offsets.

--- a/crates/varpulis-connector-kafka/src/managed.rs
+++ b/crates/varpulis-connector-kafka/src/managed.rs
@@ -135,6 +135,11 @@ pub struct ManagedKafkaConnector {
     /// Shared transaction state for exactly-once sinks. `None` when
     /// operating in fire-and-forget (at-least-once) mode.
     txn_state: Option<Arc<SharedTxnState>>,
+    /// Cooperative source-pause flag shared with the engine. While set, the
+    /// consumer loop stops pulling new records (after flushing what it holds)
+    /// so the checkpoint barrier can drain in-flight events and snapshot a
+    /// coherent offset set. `None` until the driver wires it at startup.
+    source_paused: Option<Arc<AtomicBool>>,
 }
 
 impl std::fmt::Debug for ManagedKafkaConnector {
@@ -157,6 +162,7 @@ impl ManagedKafkaConnector {
             sources: Arc::new(RwLock::new(HashMap::new())),
             engine_offsets: None,
             txn_state: None,
+            source_paused: None,
         }
     }
 
@@ -314,6 +320,7 @@ impl ManagedConnector for ManagedKafkaConnector {
         let name = self.connector_name.clone();
         let topic_owned = topic.to_string();
         let engine_offsets = self.engine_offsets.clone();
+        let source_paused = self.source_paused.clone();
 
         tokio::spawn(async move {
             use futures_util::StreamExt;
@@ -375,6 +382,35 @@ impl ManagedConnector for ManagedKafkaConnector {
             let mut cb_degraded = false;
 
             'consume: loop {
+                // C3 barrier alignment: while the engine has paused sources for
+                // a checkpoint drain, flush what we've already decoded (so it
+                // becomes drainable and its offsets are mirrored) and stop
+                // pulling new records until the barrier resumes us. Without this
+                // the barrier's drain could never reach an empty channel under
+                // sustained input.
+                if let Some(ref paused) = source_paused {
+                    if paused.load(Ordering::Relaxed) {
+                        if !batch.is_empty() {
+                            let drained =
+                                std::mem::replace(&mut batch, Vec::with_capacity(BATCH_MAX));
+                            if tx.send(drained).await.is_err() {
+                                break 'consume;
+                            }
+                            commit_pending_offsets(
+                                &mut pending_offsets,
+                                &offsets,
+                                engine_offsets.as_ref(),
+                                &name,
+                            );
+                        }
+                        tokio::time::sleep(Duration::from_millis(2)).await;
+                        if !running.load(Ordering::SeqCst) {
+                            break 'consume;
+                        }
+                        continue;
+                    }
+                }
+
                 if cb_degraded && !cb.allow_request() {
                     tokio::time::sleep(Duration::from_secs(1)).await;
                     if !running.load(Ordering::SeqCst) {
@@ -547,6 +583,10 @@ impl ManagedConnector for ManagedKafkaConnector {
 
     fn set_engine_offsets_registry(&mut self, registry: EngineOffsetRegistry) {
         self.engine_offsets = Some(registry);
+    }
+
+    fn set_source_pause_handle(&mut self, handle: Arc<AtomicBool>) {
+        self.source_paused = Some(handle);
     }
 
     async fn commit_source_offsets(

--- a/crates/varpulis-connectors/src/managed_registry.rs
+++ b/crates/varpulis-connectors/src/managed_registry.rs
@@ -89,6 +89,18 @@ impl ManagedConnectorRegistry {
         }
     }
 
+    /// Fan the engine's cooperative source-pause flag out to every managed
+    /// connector, so replayable sources stop pulling during a checkpoint
+    /// barrier's drain. Mirrors [`set_engine_offsets_registry`].
+    pub fn set_source_pause_handle(
+        &mut self,
+        handle: std::sync::Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        for connector in self.connectors.values_mut() {
+            connector.set_source_pause_handle(handle.clone());
+        }
+    }
+
     /// Commit per-partition source offsets for a given (connector, topic)
     /// pair. Called by the driver after a checkpoint has been durably
     /// persisted and all 2PC sinks have committed, closing the loop for

--- a/crates/varpulis-runtime/src/engine/barrier.rs
+++ b/crates/varpulis-runtime/src/engine/barrier.rs
@@ -4,16 +4,33 @@
 //! in-process — by tests and embedders — without a broker or the CLI connector
 //! registry. See `audit/EXACTLY_ONCE_DESIGN.md`.
 //!
-//! This first extract is deliberately behaviour-preserving: every failure is
-//! still logged and swallowed exactly as the pre-extract CLI barrier did. The
-//! `Result` return type and the [`SourceCommitCoordinator`] seam are the
-//! surfaces the later audit-C3/C4 hardening steps build on.
+//! Sink and offset failures are still logged and swallowed (the hardening step
+//! makes them fatal); the `Result` return type and the [`SourceCommitCoordinator`]
+//! seam are the surfaces those steps build on. The barrier pauses the sources
+//! and drains everything in flight before snapshotting, so committed offsets
+//! never outrun applied state (audit C3).
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use async_trait::async_trait;
 
 use super::Engine;
+use crate::event::Event;
+
+/// Resumes source ingestion on every barrier exit — success, error, or early
+/// return — so a checkpoint failure can never strand the sources paused.
+///
+/// Holds a clone of the engine's pause flag (an `Arc`), so it is independent of
+/// the `&mut self` borrow the barrier needs for the drain and snapshot.
+struct ResumeGuard(Arc<AtomicBool>);
+
+impl Drop for ResumeGuard {
+    fn drop(&mut self) {
+        self.0.store(false, Ordering::Release);
+    }
+}
 
 /// Error surfaced by [`Engine::barrier_commit_2pc`].
 ///
@@ -68,17 +85,36 @@ impl Engine {
     /// it, commit transactional sinks, then commit source offsets — as a single
     /// checkpoint epoch.
     ///
-    /// Extracted from the CLI `run` loop (behaviour-preserving). All failures are
-    /// logged and swallowed exactly as before; the `Result` return is the seam
-    /// the later audit-C3/C4 steps use to make failing paths fatal. See the
-    /// module docs.
+    /// Extracted from the CLI `run` loop. Sink/offset failures are still logged
+    /// and swallowed (the hardening step makes them fatal); the `Result` return
+    /// is that seam. See the module docs.
+    ///
+    /// **C3 — drain before snapshot.** Sources mirror their offsets at channel
+    /// ingress, so a naive snapshot can record an offset for an event that has
+    /// not yet been applied to engine state. Committing that offset and then
+    /// crashing would skip the event on restart (data loss). To prevent it, the
+    /// barrier first pauses the sources and drains everything already in flight
+    /// (`event_rx`) into engine state, so the snapshot's offsets reflect
+    /// *applied* state. Sources are resumed on every exit via [`ResumeGuard`].
     #[cfg(feature = "async-runtime")]
     pub async fn barrier_commit_2pc(
         &mut self,
         checkpoint_id: u64,
+        event_rx: &mut tokio::sync::mpsc::Receiver<Vec<Event>>,
         coordinator: &dyn SourceCommitCoordinator,
     ) -> Result<(), BarrierError> {
-        // Phase 1 — state snapshot (fast, in-memory).
+        // C3 — pause sources and drain all in-flight events before snapshotting.
+        // The guard resumes ingestion no matter how this method returns.
+        let _resume = ResumeGuard(self.source_pause_handle());
+        self.pause_sources();
+
+        while let Ok(batch) = event_rx.try_recv() {
+            if let Err(e) = self.process_batch(batch).await {
+                tracing::warn!("Barrier drain apply failed (epoch {checkpoint_id}): {e}");
+            }
+        }
+
+        // Phase 1 — state snapshot (offsets now reflect applied state, post-drain).
         let snapshot = self.create_checkpoint();
 
         // Resolve the offset-commit targets up front (while we still hold the
@@ -241,8 +277,9 @@ mod tests {
             .insert("src".to_string(), HashMap::from([(0, 42)]));
 
         let coordinator = CaptureCoordinator::default();
+        let (_evt_tx, mut evt_rx) = tokio::sync::mpsc::channel::<Vec<Event>>(16);
         engine
-            .barrier_commit_2pc(1, &coordinator)
+            .barrier_commit_2pc(1, &mut evt_rx, &coordinator)
             .await
             .expect("barrier should succeed");
 
@@ -272,5 +309,106 @@ mod tests {
         assert_eq!(connector, "src");
         assert_eq!(topic, "varpulis/events/#");
         assert_eq!(offsets.get(&0), Some(&42));
+    }
+
+    /// C3 — the barrier drains in-flight events before snapshotting, so a crash
+    /// right after the offset commit cannot skip an event whose offset was
+    /// mirrored at ingress but never applied.
+    ///
+    /// Fail-before: delete the drain loop in `barrier_commit_2pc` and the
+    /// recovered engine shows `events_processed == 3` — the event at offset 3
+    /// was counted in the committed offset but lost from state.
+    #[tokio::test]
+    async fn drain_before_snapshot_prevents_inflight_event_loss_across_restart() {
+        use crate::persistence::{CheckpointConfig, MemoryStore};
+
+        let vpl = "stream PassThrough = TestEvent\n    .emit(value: value)\n";
+        let program = varpulis_parser::parse(vpl).expect("parse passthrough VPL");
+
+        // The durable store survives the "crash".
+        let store = Arc::new(MemoryStore::new());
+
+        // --- Run 1: apply offsets 0,1,2; leave offset 3 in flight; barrier; crash. ---
+        let (tx1, _rx1) = tokio::sync::mpsc::channel::<Event>(64);
+        let mut engine1 = Engine::new(tx1);
+        engine1.load(&program).expect("load");
+        engine1
+            .enable_checkpointing(store.clone(), CheckpointConfig::default())
+            .expect("enable checkpointing");
+
+        // A source binding so the barrier commits this source's offsets.
+        engine1.source_bindings.push(SourceBinding {
+            connector_name: "src".to_string(),
+            event_type: "TestEvent".to_string(),
+            topic_override: None,
+            extra_params: HashMap::new(),
+        });
+
+        // Events at offsets 0,1,2 are mirrored AND applied.
+        for id in 0..3 {
+            engine1
+                .process(Event::new("TestEvent").with_field("value", id))
+                .await
+                .expect("process");
+        }
+        // The source has also read + mirrored offset 3 (event in flight), but it
+        // is not yet applied — it sits unread in the event channel.
+        engine1
+            .source_offsets_handle()
+            .lock()
+            .unwrap()
+            .insert("src".to_string(), HashMap::from([(0, 3)]));
+        let (evt_tx, mut evt_rx) = tokio::sync::mpsc::channel::<Vec<Event>>(16);
+        evt_tx
+            .send(vec![Event::new("TestEvent").with_field("value", 3)])
+            .await
+            .expect("queue in-flight event");
+        drop(evt_tx);
+
+        assert_eq!(
+            engine1.metrics().events_processed,
+            3,
+            "only offsets 0,1,2 applied before the barrier"
+        );
+
+        let coordinator = CaptureCoordinator::default();
+        engine1
+            .barrier_commit_2pc(1, &mut evt_rx, &coordinator)
+            .await
+            .expect("barrier");
+
+        // The barrier drained + applied the in-flight event before snapshotting.
+        assert_eq!(
+            engine1.metrics().events_processed,
+            4,
+            "drain must apply the in-flight event before the snapshot"
+        );
+        // The committed source offset is 3, as mirrored at ingress.
+        let committed = coordinator.committed.lock().unwrap().clone();
+        assert_eq!(
+            committed.len(),
+            1,
+            "expected one offset commit: {committed:?}"
+        );
+        assert_eq!(committed[0].2.get(&0), Some(&3));
+
+        drop(engine1); // "crash": engine + in-flight channel are gone.
+
+        // --- Restart: a fresh engine recovers from the same store. ---
+        let (tx2, _rx2) = tokio::sync::mpsc::channel::<Event>(64);
+        let mut engine2 = Engine::new(tx2);
+        engine2.load(&program).expect("load");
+        engine2
+            .enable_checkpointing(store.clone(), CheckpointConfig::default())
+            .expect("recover");
+
+        // Committed offset is 3, so the source replays nothing past it. Every
+        // event through offset 3 must therefore be reflected in recovered state.
+        assert_eq!(
+            engine2.metrics().events_processed,
+            4,
+            "all four events must survive the crash; a short count means the \
+             in-flight event was lost (committed offset outran applied state)"
+        );
     }
 }


### PR DESCRIPTION
## What

**Audit critical C3 — offset outruns applied state.** Fixes a silent data-loss window in the checkpoint barrier.

Sources mirror their consumed offsets into the engine registry **at channel ingress** — before the event is applied to engine state. So a checkpoint could snapshot and commit a source offset for an event still sitting unapplied in the run-loop channel. A crash right after that offset commit would resume **past** the event on restart: the committed offset says "consumed" while state never reflected it. Lost data — with exactly-once advertised.

Stacked on #187 (the barrier extract).

## How

The barrier now **pauses sources and drains everything in flight before snapshotting**, so the snapshot's offsets reflect *applied* state:

```
pause_sources → drain (try_recv until empty, process_batch each) → snapshot → persist → prepare/commit sinks → commit offsets
```

- A `ResumeGuard` resumes ingestion on **every** exit (including the error returns the hardening step will add), so a failed barrier can never strand sources paused.
- `Engine::barrier_commit_2pc` gains a `&mut Receiver<Vec<Event>>` param for the drain; both CLI call sites pass their `event_rx`.

**Connector plumbing** so the live path's drain actually terminates: new `ManagedConnector::set_source_pause_handle` (default no-op), fanned out by the registry, honored by the Kafka consumer loop — while paused it flushes its partial batch (mirroring those offsets), then stops pulling and idle-polls until resumed. Without it a busy source could refill the channel faster than the drain empties it.

## Test (fail-before / pass-after gate)

`drain_before_snapshot_prevents_inflight_event_loss_across_restart` — a real in-memory crash/restart:

1. apply 3 events (offsets 0,1,2);
2. mirror a 4th event's offset (3) but leave it **unapplied** in the channel;
3. run the barrier, then **"crash"** (drop the engine);
4. recover a fresh engine from the same `MemoryStore`.

With the drain, all four events survive the crash (`events_processed == 4`). **Verified fail-before:** neutralizing the drain loop → the recovered engine reports **3** — the offset-3 event is lost (committed offset outran applied state).

The real-broker end-to-end equivalents stay `#[ignore]` (need a live Kafka); the Kafka consumer-loop pause is exercised by those + validated here by the in-memory engine drain.

578 runtime lib tests pass; `make verify` green.

## Exactly-once progress
- [x] 0a extract barrier (#187)
- [x] **1 — C3 drain-before-snapshot (this PR)**
- [ ] 2 — C4 atomic offset+txn commit
- [ ] 3 — barrier hardening (Result propagation, epoch bump only on success)

🤖 Generated with [Claude Code](https://claude.com/claude-code)