### PR TITLE
fix(cluster): detect dead workers via a replicated heartbeat sequence (audit C5)

### DIFF
--- a/crates/varpulis-cluster/src/api.rs
+++ b/crates/varpulis-cluster/src/api.rs
@@ -624,6 +624,8 @@ async fn handle_register_worker(
                                 last_heartbeat: std::time::Instant::now(),
                                 assigned_pipelines: Vec::new(),
                                 events_processed: 0,
+                                heartbeat_seq: 0,
+                                last_seen_hb_seq: 0,
                             };
                             let id = coord.register_worker(node);
                             let reg_resp = RegisterWorkerResponse {
@@ -683,6 +685,8 @@ async fn handle_register_worker(
         last_heartbeat: std::time::Instant::now(),
         assigned_pipelines: Vec::new(),
         events_processed: 0,
+        heartbeat_seq: 0,
+        last_seen_hb_seq: 0,
     };
     let id = coord.register_worker(node);
     let resp = RegisterWorkerResponse {
@@ -708,11 +712,20 @@ async fn handle_heartbeat(
             // up-to-date events_processed and pipelines_running.
             #[cfg(feature = "raft")]
             {
+                // Read back the monotonic heartbeat counter that `heartbeat()`
+                // just advanced for this worker; replicating it is what lets
+                // other coordinators detect liveness (see `sync_from_raft`).
+                let heartbeat_seq = coord
+                    .workers
+                    .get(&WorkerId(worker_id.clone()))
+                    .map(|w| w.heartbeat_seq)
+                    .unwrap_or(0);
                 let cmd = crate::raft::ClusterCommand::WorkerMetricsUpdated {
                     id: worker_id,
                     events_processed: body.events_processed,
                     pipelines_running: body.pipelines_running,
                     pipeline_metrics: body.pipeline_metrics.clone(),
+                    heartbeat_seq,
                 };
                 if coord.is_raft_leader() {
                     // Leader: write directly to Raft log

--- a/crates/varpulis-cluster/src/coordinator/mod.rs
+++ b/crates/varpulis-cluster/src/coordinator/mod.rs
@@ -380,13 +380,19 @@ impl Coordinator {
                 }
                 local.capacity.pipelines_running = entry.pipelines_running;
                 // Trust Raft status for cross-coordinator transitions (e.g., unhealthy).
-                // If Raft says a worker is ready, refresh last_heartbeat -- this acts
-                // as a heartbeat proxy for workers connected to other coordinators.
+                // If Raft says a worker is ready, only refresh last_heartbeat when the
+                // replicated liveness signal (heartbeat_seq) has actually ADVANCED since
+                // we last synced. This acts as a heartbeat proxy for workers connected to
+                // other coordinators WITHOUT masking a dead worker: if no new heartbeat is
+                // replicated, the seq stays put, last_heartbeat goes stale, and the local
+                // health_sweep can time the worker out. (Unconditionally stamping here was
+                // the C5 bug: it reset the clock every tick so dead workers stayed Ready.)
                 match raft_status {
                     WorkerStatus::Unhealthy | WorkerStatus::Draining => {
                         local.status = raft_status;
                     }
-                    WorkerStatus::Ready => {
+                    WorkerStatus::Ready if entry.heartbeat_seq > local.last_seen_hb_seq => {
+                        local.last_seen_hb_seq = entry.heartbeat_seq;
                         local.last_heartbeat = Instant::now();
                     }
                     _ => {}
@@ -406,6 +412,12 @@ impl Coordinator {
                     last_heartbeat: Instant::now(),
                     assigned_pipelines: entry.assigned_pipelines.clone(),
                     events_processed: entry.events_processed,
+                    // Not this coordinator's local worker, so its own send-side
+                    // counter starts at 0; seed last_seen from the replicated value
+                    // and stamp once (a just-learned worker is presumed alive until
+                    // its timeout elapses with no further seq advance).
+                    heartbeat_seq: 0,
+                    last_seen_hb_seq: entry.heartbeat_seq,
                 };
                 self.workers.insert(wid, worker);
             }
@@ -519,6 +531,11 @@ impl Coordinator {
         worker.last_heartbeat = std::time::Instant::now();
         worker.capacity.pipelines_running = hb.pipelines_running;
         worker.events_processed = hb.events_processed;
+        // Advance the monotonic liveness counter. This is the single source of
+        // truth for both the HTTP and NATS heartbeat paths; the receiving
+        // coordinator replicates this value through Raft (WorkerMetricsUpdated)
+        // so other coordinators can tell a live worker from a dead one.
+        worker.heartbeat_seq = worker.heartbeat_seq.wrapping_add(1);
 
         // If worker was unhealthy and heartbeat arrives, mark it ready again
         if worker.status == WorkerStatus::Unhealthy {

--- a/crates/varpulis-cluster/src/nats_coordinator.rs
+++ b/crates/varpulis-cluster/src/nats_coordinator.rs
@@ -96,6 +96,8 @@ async fn handle_registration(payload: &[u8], coordinator: &SharedCoordinator) ->
         last_heartbeat: std::time::Instant::now(),
         assigned_pipelines: Vec::new(),
         events_processed: 0,
+        heartbeat_seq: 0,
+        last_seen_hb_seq: 0,
     };
 
     let mut coord = coordinator.write().await;
@@ -135,4 +137,15 @@ async fn handle_heartbeat_message(subject: &str, payload: &[u8], coordinator: &S
     if let Err(e) = coord.heartbeat(&wid, &hb) {
         warn!("Heartbeat error for {}: {}", worker_id, e);
     }
+    // NOTE (C5 / C6 follow-up): unlike the HTTP heartbeat handler
+    // (`api.rs` `handle_heartbeat`), this NATS path advances the worker's
+    // local `heartbeat_seq` via `heartbeat()` but does NOT replicate a
+    // `WorkerMetricsUpdated` through Raft — the NATS handler doesn't replicate
+    // metrics at all today. That is fine for a single coordinator (its own
+    // `heartbeat()` keeps `last_heartbeat` fresh) but means that in a
+    // multi-coordinator NATS deployment a worker homed on a *non-leader* would
+    // not have its liveness seen by the leader's `sync_from_raft`. Wiring
+    // leader-write-or-forward replication here belongs with the NATS outbound
+    // work (audit C6); until then, prefer HTTP heartbeats for multi-coordinator
+    // liveness.
 }

--- a/crates/varpulis-cluster/src/raft/mod.rs
+++ b/crates/varpulis-cluster/src/raft/mod.rs
@@ -90,6 +90,12 @@ pub enum ClusterCommand {
         pipelines_running: usize,
         #[serde(default)]
         pipeline_metrics: Vec<crate::worker::PipelineMetrics>,
+        /// Monotonic per-worker heartbeat counter (liveness signal). Advances
+        /// once per received heartbeat; `sync_from_raft` refreshes a worker's
+        /// `last_heartbeat` only when this value moves forward. `#[serde(default)]`
+        /// keeps older replicated/persisted commands deserializable.
+        #[serde(default)]
+        heartbeat_seq: u64,
     },
 
     // -- Pipeline groups --

--- a/crates/varpulis-cluster/src/raft/state_machine.rs
+++ b/crates/varpulis-cluster/src/raft/state_machine.rs
@@ -65,6 +65,16 @@ pub struct WorkerEntry {
     pub max_pipelines: usize,
     pub assigned_pipelines: Vec<String>,
     pub events_processed: u64,
+    /// Monotonic per-worker heartbeat counter.
+    ///
+    /// Incremented by whichever coordinator receives a worker's heartbeat and
+    /// replicated through Raft (via [`ClusterCommand::WorkerMetricsUpdated`]).
+    /// `sync_from_raft` treats a worker as freshly-alive only when this value
+    /// advances, so a dead worker (no new heartbeats ⇒ seq frozen) is eventually
+    /// timed out by the health sweep instead of being kept `Ready` forever.
+    /// `#[serde(default)]` keeps pre-existing snapshots deserializable.
+    #[serde(default)]
+    pub heartbeat_seq: u64,
 }
 
 // ---------------------------------------------------------------------------
@@ -92,6 +102,7 @@ pub fn apply_command(state: &mut CoordinatorState, cmd: ClusterCommand) -> Clust
                     max_pipelines: capacity.max_pipelines,
                     assigned_pipelines: Vec::new(),
                     events_processed: 0,
+                    heartbeat_seq: 0,
                 },
             );
             ClusterResponse::Ok
@@ -124,10 +135,12 @@ pub fn apply_command(state: &mut CoordinatorState, cmd: ClusterCommand) -> Clust
             events_processed,
             pipelines_running,
             pipeline_metrics,
+            heartbeat_seq,
         } => {
             if let Some(w) = state.workers.get_mut(&id) {
                 w.events_processed = events_processed;
                 w.pipelines_running = pipelines_running;
+                w.heartbeat_seq = heartbeat_seq;
             }
             if !pipeline_metrics.is_empty() {
                 state.worker_pipeline_metrics.insert(id, pipeline_metrics);
@@ -264,6 +277,7 @@ mod tests {
                 max_pipelines: 100,
                 assigned_pipelines: vec![],
                 events_processed: 0,
+                heartbeat_seq: 0,
             },
         );
         let cmd = ClusterCommand::DeregisterWorker { id: "w1".into() };
@@ -286,6 +300,7 @@ mod tests {
                 max_pipelines: 100,
                 assigned_pipelines: vec![],
                 events_processed: 0,
+                heartbeat_seq: 0,
             },
         );
         let cmd = ClusterCommand::WorkerStatusChanged {
@@ -376,10 +391,12 @@ mod tests {
                 events_out: 100,
                 connector_health: vec![],
             }],
+            heartbeat_seq: 7,
         };
         apply_command(&mut state, cmd);
         assert_eq!(state.workers["w1"].events_processed, 5000);
         assert_eq!(state.workers["w1"].pipelines_running, 3);
+        assert_eq!(state.workers["w1"].heartbeat_seq, 7);
         assert_eq!(state.worker_pipeline_metrics["w1"].len(), 1);
         assert_eq!(state.worker_pipeline_metrics["w1"][0].events_in, 5000);
 
@@ -389,10 +406,12 @@ mod tests {
             events_processed: 12000,
             pipelines_running: 2,
             pipeline_metrics: vec![],
+            heartbeat_seq: 9,
         };
         apply_command(&mut state, cmd);
         assert_eq!(state.workers["w1"].events_processed, 12000);
         assert_eq!(state.workers["w1"].pipelines_running, 2);
+        assert_eq!(state.workers["w1"].heartbeat_seq, 9);
         // Empty pipeline_metrics should not overwrite existing data
         assert_eq!(state.worker_pipeline_metrics["w1"].len(), 1);
     }
@@ -406,6 +425,7 @@ mod tests {
             events_processed: 100,
             pipelines_running: 1,
             pipeline_metrics: vec![],
+            heartbeat_seq: 1,
         };
         let resp = apply_command(&mut state, cmd);
         assert!(matches!(resp, ClusterResponse::Ok));

--- a/crates/varpulis-cluster/src/worker.rs
+++ b/crates/varpulis-cluster/src/worker.rs
@@ -73,6 +73,14 @@ pub struct WorkerNode {
     pub assigned_pipelines: Vec<String>,
     /// Total events processed by this worker (from heartbeats).
     pub events_processed: u64,
+    /// Monotonic heartbeat counter maintained by this coordinator for the
+    /// worker. Incremented once per heartbeat received in [`Coordinator::heartbeat`]
+    /// and replicated through Raft so other coordinators can detect liveness.
+    pub heartbeat_seq: u64,
+    /// Highest replicated `heartbeat_seq` this coordinator has already observed
+    /// for the worker via `sync_from_raft`. Used to refresh `last_heartbeat`
+    /// only when the replicated liveness signal actually advances.
+    pub last_seen_hb_seq: u64,
 }
 
 impl WorkerNode {
@@ -86,6 +94,8 @@ impl WorkerNode {
             last_heartbeat: Instant::now(),
             assigned_pipelines: Vec::new(),
             events_processed: 0,
+            heartbeat_seq: 0,
+            last_seen_hb_seq: 0,
         }
     }
 

--- a/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
+++ b/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
@@ -179,6 +179,8 @@ async fn test_deploy_pipeline_group_across_workers() {
             last_heartbeat: std::time::Instant::now(),
             assigned_pipelines: Vec::new(),
             events_processed: 0,
+            heartbeat_seq: 0,
+            last_seen_hb_seq: 0,
         };
         coord.register_worker(node0);
 
@@ -191,6 +193,8 @@ async fn test_deploy_pipeline_group_across_workers() {
             last_heartbeat: std::time::Instant::now(),
             assigned_pipelines: Vec::new(),
             events_processed: 0,
+            heartbeat_seq: 0,
+            last_seen_hb_seq: 0,
         };
         coord.register_worker(node1);
     }
@@ -333,6 +337,8 @@ async fn test_inject_events_to_both_workers() {
                 last_heartbeat: std::time::Instant::now(),
                 assigned_pipelines: Vec::new(),
                 events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
             };
             coord.register_worker(node);
         }
@@ -532,6 +538,8 @@ async fn test_worker_drain_state_transitions() {
                 last_heartbeat: std::time::Instant::now(),
                 assigned_pipelines: Vec::new(),
                 events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
             };
             coord.register_worker(node);
         }

--- a/crates/varpulis-cluster/tests/raft_sim_tests.rs
+++ b/crates/varpulis-cluster/tests/raft_sim_tests.rs
@@ -942,3 +942,92 @@ async fn concurrent_writes_during_partition_heal() {
     let state = cluster.shared_states[&1].read().unwrap();
     assert_eq!(state.workers.len(), 8);
 }
+
+// =========================================================================
+// Test 9: C5 regression — replicated liveness detects a dead worker
+// =========================================================================
+
+/// Regression test for audit critical **C5** (Raft dead-worker detection).
+///
+/// A worker that Raft still lists as `ready` but has stopped heartbeating must
+/// eventually be marked `Unhealthy` by the local health sweep. Before the fix,
+/// `sync_from_raft` unconditionally reset `last_heartbeat` to `Instant::now()`
+/// for every `Ready` worker on every tick, so `last_heartbeat.elapsed()` was
+/// always ≈0 and `health_sweep` could never time a dead worker out. The fix
+/// replicates a monotonic `heartbeat_seq` through Raft and refreshes
+/// `last_heartbeat` only when that signal advances.
+///
+/// Wholly in-memory: a single-node Raft built with the `SimRouter` harness and
+/// wrapped in a real `Coordinator`. No NATS, no sockets, no mocking.
+///
+/// Fail-before / pass-after gate: reverting only the `sync_from_raft` conditional
+/// (restoring the unconditional stamp) makes the `w-dead` assertion fail because
+/// the worker stays `Ready` forever.
+#[tokio::test]
+async fn c5_dead_worker_times_out_live_worker_stays_ready() {
+    use varpulis_cluster::worker::{WorkerId, WorkerStatus};
+    use varpulis_cluster::Coordinator;
+
+    // 1-node in-memory Raft; wait until it has elected itself leader so writes
+    // commit and apply locally.
+    let cluster = SimCluster::new(1, get_seed()).await;
+    cluster.wait_for_leader(Duration::from_secs(5)).await;
+
+    let raft = cluster.rafts[&1].clone();
+    let shared_state = cluster.shared_states[&1].clone();
+
+    // Wrap the same Raft node + shared state in a real Coordinator.
+    let mut coord = Coordinator::with_raft(raft.clone(), shared_state, BTreeMap::new(), None);
+    // Short timeout so the test is fast. `health_sweep` uses std::time::Instant,
+    // so the loop below sleeps on real wall-clock time.
+    coord.heartbeat_timeout = Duration::from_millis(100);
+
+    // Register two workers through Raft. Both start with heartbeat_seq = 0.
+    raft.client_write(make_register("w-dead", 4))
+        .await
+        .expect("register w-dead");
+    raft.client_write(make_register("w-alive", 4))
+        .await
+        .expect("register w-alive");
+
+    let dead = WorkerId("w-dead".to_string());
+    let alive = WorkerId("w-alive".to_string());
+
+    // Drive several sweep cycles with a real sleep (> timeout) between them.
+    // Every iteration `w-alive` gets a fresh, advancing replicated heartbeat_seq
+    // (it is alive); `w-dead` never does (it is dead), so its seq stays frozen.
+    for seq in 1..=4u64 {
+        raft.client_write(ClusterCommand::WorkerMetricsUpdated {
+            id: "w-alive".to_string(),
+            events_processed: 0,
+            pipelines_running: 0,
+            pipeline_metrics: vec![],
+            heartbeat_seq: seq,
+        })
+        .await
+        .expect("heartbeat for w-alive");
+
+        coord.sync_from_raft();
+        coord.health_sweep();
+
+        // Real wall-clock sleep so Instant::elapsed() actually crosses the
+        // heartbeat_timeout (the default tokio test runtime is not time-paused).
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // `w-dead`: replicated seq never advanced past its initial value, so
+    // `last_heartbeat` went stale and the sweep timed it out.
+    assert_eq!(
+        coord.workers[&dead].status,
+        WorkerStatus::Unhealthy,
+        "C5: a worker whose replicated heartbeat_seq stopped advancing must be marked Unhealthy"
+    );
+
+    // Positive control: `w-alive` kept advancing its seq, so every sweep saw a
+    // fresh last_heartbeat and left it Ready.
+    assert_eq!(
+        coord.workers[&alive].status,
+        WorkerStatus::Ready,
+        "positive control: a worker whose heartbeat_seq keeps advancing must stay Ready"
+    );
+}

--- a/crates/varpulis-cluster/tests/raft_simulation_tests.rs
+++ b/crates/varpulis-cluster/tests/raft_simulation_tests.rs
@@ -39,6 +39,7 @@ fn make_metrics(id: &str, events: u64, pipelines: usize) -> ClusterCommand {
         events_processed: events,
         pipelines_running: pipelines,
         pipeline_metrics: vec![],
+        heartbeat_seq: events,
     }
 }
 


### PR DESCRIPTION
## What

**Audit critical C5 — Raft dead-worker never detected.** `sync_from_raft` unconditionally stamped `local.last_heartbeat = Instant::now()` for any `ready` worker (`coordinator/mod.rs:390`), and the failover loop runs `sync_from_raft()` right before `health_sweep()` — so `last_heartbeat.elapsed()` was always ~0 and a dead worker stayed `Ready` **forever**. Root cause: **no liveness signal was replicated through Raft at all** (`WorkerEntry` had no heartbeat timestamp/seq), so coordinators faked freshness by resetting the clock.

## How (design §4 Option A — monotonic sequence)

- `WorkerEntry` + `WorkerMetricsUpdated` gain `#[serde(default)] heartbeat_seq: u64` (back-compatible with old snapshots/commands).
- `Coordinator::heartbeat` advances a per-worker monotonic counter — one source of truth for both transports. The **HTTP** heartbeat handler replicates it through Raft (leader-write-or-forward) alongside the existing metrics.
- `sync_from_raft` refreshes `last_heartbeat` **only when the replicated `heartbeat_seq` advanced** since the last sync (per-worker `last_seen_hb_seq`). No new heartbeat → seq frozen → `last_heartbeat` goes stale → `health_sweep` times the worker out.

This keeps the **multi-coordinator heartbeat-proxy** (a worker homed on another coordinator stays alive via its replicated advances) *without masking a dead one* — so the naive "just delete the stamp" (which would false-positive remote workers) is avoided.

## Test — fail-before / pass-after (in-memory, non-ignored, no broker, no mocking)

`raft_sim_tests::c5_dead_worker_times_out_live_worker_stays_ready`: a 1-node in-memory Raft (`SimRouter` harness) wrapped in a **real** `Coordinator`, two registered workers, sweep cycles where one worker's replicated `heartbeat_seq` keeps advancing and the other's is frozen.
- Dead (frozen) worker → **`Unhealthy`**; live (advancing) worker → **`Ready`** (positive control).
- **Verified fail-before:** restoring the unconditional stamp → dead worker stays `Ready` → test fails (`left: Ready, right: Unhealthy`). Re-verified independently in this session.

Cluster raft suites green (**9** `raft_sim` + **9** `raft_simulation` + **218** lib); `make verify` green; raft- and nats-transport-feature clippy clean.

## Known limitation (documented in `nats_coordinator.rs`)

The **NATS** heartbeat path advances the local seq but does **not yet replicate it** through Raft (that path replicates no metrics today). So multi-coordinator liveness for **NATS-homed** workers awaits the NATS outbound work (**audit C6** — see the cluster design doc). Single-coordinator (any transport) and multi-coordinator **HTTP** are correct. Cluster is **pre-release**, and a false-detection there fails *safe* (`handle_worker_failure` collects+discards migration errors).

## Criticals: 5 of 6

C1 ✅ · C2 ✅ · C3 ✅ · C4 ✅ · **C5 ✅ (this PR)** · C6 ⏳ (NATS outbound — needs a broker session; design doc ready).

🤖 Generated with [Claude Code](https://claude.com/claude-code)