### PR TITLE
fix(cluster): route deploy/teardown/inject over NATS when configured (audit C6a)

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,32 @@
+name: Free disk space
+description: >
+  Reclaim disk on GitHub-hosted ubuntu-latest runners before a heavy build.
+  The runner ships with only ~14 GB free on /, which the full-workspace
+  all-targets build plus nextest/coverage test binaries can exhaust
+  ("No space left on device"). This deletes preinstalled language toolchains
+  that a Rust build never uses (~20-25 GB). Self-contained — no third-party
+  action, so nothing new enters the supply chain.
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        echo "Disk before cleanup:"
+        df -h /
+        # Toolchains that are definitively unused by this Rust workspace.
+        # `|| true` so a missing path on a future runner image is not fatal.
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost \
+          /usr/local/graalvm \
+          /usr/local/share/powershell \
+          /usr/share/swift \
+          /usr/local/share/chromium \
+          /usr/local/lib/node_modules || true
+        echo "Disk after cleanup:"
+        df -h /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@1.93
       - uses: Swatinem/rust-cache@v2
         with:
@@ -70,6 +71,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install connector system dependencies
@@ -83,6 +85,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -276,6 +279,7 @@ jobs:
           - all-connectors
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -333,6 +337,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov

--- a/crates/varpulis-cli/src/commands/coordinator.rs
+++ b/crates/varpulis-cli/src/commands/coordinator.rs
@@ -240,22 +240,29 @@ pub async fn run_coordinator(
 
     let coordinator = varpulis_cluster::shared_coordinator();
 
-    // Spawn NATS coordinator handler if NATS URL is configured
+    // Connect NATS and spawn the inbound coordinator handler if a NATS URL is
+    // configured. Keep a clone of the client so it can be stored on the
+    // coordinator below for the OUTBOUND command path (deploy/teardown/inject);
+    // the handler task gets its own clone.
     #[cfg(feature = "nats-transport")]
-    if let Some(ref nurl) = nats_url {
+    let coordinator_nats_client = if let Some(ref nurl) = nats_url {
         let nats_client = varpulis_cluster::nats_transport::connect_nats(nurl)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to connect to NATS: {}", e))?;
         info!("Coordinator connected to NATS at {}", nurl);
         let coord_for_nats = coordinator.clone();
+        let handler_client = nats_client.clone();
         tokio::spawn(async move {
             varpulis_cluster::nats_coordinator::run_coordinator_nats_handler(
-                nats_client,
+                handler_client,
                 coord_for_nats,
             )
             .await;
         });
-    }
+        Some(nats_client)
+    } else {
+        None
+    };
     #[cfg(not(feature = "nats-transport"))]
     let _ = &nats_url;
 
@@ -291,6 +298,13 @@ pub async fn run_coordinator(
                 peer_addrs: raft_peer_addrs_map.clone(),
                 admin_key: rbac.any_admin_key(),
             });
+        }
+
+        // Store the outbound NATS client so the deploy/teardown/inject REST
+        // handlers route commands over NATS (not HTTP) in a NATS deployment.
+        #[cfg(feature = "nats-transport")]
+        {
+            coord.nats_client = coordinator_nats_client;
         }
     }
 

--- a/crates/varpulis-cluster/src/api.rs
+++ b/crates/varpulis-cluster/src/api.rs
@@ -868,19 +868,40 @@ async fn handle_deploy_group(
         return resp;
     }
 
-    // Phase 1: Plan (read lock — released before HTTP I/O)
-    let (plan, http_client) = {
-        let coord = coordinator.read().await;
-
-        match coord.plan_deploy_group(&body) {
-            Ok(plan) => (plan, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (plan, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let (plan, results) = {
+        let (plan, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_deploy_group(&body) {
+                Ok(plan) => (plan, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        let results = crate::coordinator::Coordinator::execute_deploy_plan_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &plan,
+        )
+        .await;
+        (plan, results)
     };
-    // Read lock released here
-
-    // Phase 2: Execute HTTP deploys (no lock held)
-    let results = crate::coordinator::Coordinator::execute_deploy_plan(&http_client, &plan).await;
+    #[cfg(not(feature = "nats-transport"))]
+    let (plan, results) = {
+        let (plan, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_deploy_group(&body) {
+                Ok(plan) => (plan, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        let results =
+            crate::coordinator::Coordinator::execute_deploy_plan(&http_client, &plan).await;
+        (plan, results)
+    };
 
     // Phase 3: Commit results (write lock)
     let mut coord = coordinator.write().await;
@@ -992,19 +1013,39 @@ async fn handle_delete_group(
         return resp;
     }
 
-    // Phase 1: Plan teardown under read lock
-    let (plan, http_client) = {
-        let coord = coordinator.read().await;
-
-        match coord.plan_teardown_group(&group_id) {
-            Ok(plan) => (plan, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (plan teardown, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let plan = {
+        let (plan, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_teardown_group(&group_id) {
+                Ok(plan) => (plan, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_teardown_plan_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &plan,
+        )
+        .await;
+        plan
     };
-    // Read lock released here
-
-    // Phase 2: Execute HTTP teardown without lock
-    crate::coordinator::Coordinator::execute_teardown_plan(&http_client, &plan).await;
+    #[cfg(not(feature = "nats-transport"))]
+    let plan = {
+        let (plan, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_teardown_group(&group_id) {
+                Ok(plan) => (plan, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_teardown_plan(&http_client, &plan).await;
+        plan
+    };
 
     // Phase 3: Commit state changes under write lock
     let mut coord = coordinator.write().await;
@@ -1052,19 +1093,40 @@ async fn handle_inject_event(
     {
         return resp;
     }
-    // Phase 1: Resolve target under read lock
-    let (target, http_client) = {
-        let coord = coordinator.read().await;
-        match coord.resolve_inject_target(&group_id, &body) {
-            Ok(target) => (target, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (resolve target, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let inject_result = {
+        let (target, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.resolve_inject_target(&group_id, &body) {
+                Ok(target) => (target, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_inject_event_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &target,
+            &body,
+        )
+        .await
     };
-    // Read lock released here
+    #[cfg(not(feature = "nats-transport"))]
+    let inject_result = {
+        let (target, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.resolve_inject_target(&group_id, &body) {
+                Ok(target) => (target, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_inject_event(&http_client, &target, &body).await
+    };
 
-    // Phase 2: Execute HTTP without lock
-    match crate::coordinator::Coordinator::execute_inject_event(&http_client, &target, &body).await
-    {
+    match inject_result {
         Ok(resp) => reply_json_status(&resp, StatusCode::OK),
         Err(e) => cluster_error_response(e),
     }

--- a/crates/varpulis-cluster/src/coordinator/deployment.rs
+++ b/crates/varpulis-cluster/src/coordinator/deployment.rs
@@ -251,6 +251,24 @@ impl Coordinator {
         results
     }
 
+    /// Execute a deployment plan over the best available transport.
+    ///
+    /// Routes over NATS request/reply when a NATS client is configured
+    /// (a NATS deployment, where worker addresses are `nats://...`), otherwise
+    /// falls back to HTTP. This is the single entry point the REST deploy
+    /// handler calls, so transport selection lives in exactly one place.
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_deploy_plan_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        plan: &DeployGroupPlan,
+    ) -> Vec<DeployTaskResult> {
+        match nats {
+            Some(n) => Self::execute_deploy_plan_nats(n, plan).await,
+            None => Self::execute_deploy_plan(http, plan).await,
+        }
+    }
+
     /// Phase 3: Commit deployment results to coordinator state.
     #[tracing::instrument(skip(self, plan, results), fields(group_id = %plan.group_id, group = %plan.spec.name))]
     pub fn commit_deploy_group(
@@ -726,6 +744,21 @@ impl Coordinator {
         }
     }
 
+    /// Execute a teardown plan over the best available transport.
+    ///
+    /// NATS when a client is configured, otherwise HTTP (unchanged default).
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_teardown_plan_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        plan: &TeardownPlan,
+    ) {
+        match nats {
+            Some(n) => Self::execute_teardown_plan_nats(n, plan).await,
+            None => Self::execute_teardown_plan(http, plan).await,
+        }
+    }
+
     /// Execute inject event via NATS request/reply.
     #[cfg(feature = "nats-transport")]
     pub async fn execute_inject_event_nats(
@@ -753,6 +786,22 @@ impl Coordinator {
             worker_id: target.worker_id.clone(),
             worker_response,
         })
+    }
+
+    /// Execute an inject event over the best available transport.
+    ///
+    /// NATS when a client is configured, otherwise HTTP (unchanged default).
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_inject_event_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        target: &InjectTarget,
+        event: &InjectEventRequest,
+    ) -> Result<InjectResponse, ClusterError> {
+        match nats {
+            Some(n) => Self::execute_inject_event_nats(n, target, event).await,
+            None => Self::execute_inject_event(http, target, event).await,
+        }
     }
 
     /// Convenience wrapper: resolve + execute inject event in one call.

--- a/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
+++ b/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
@@ -628,3 +628,160 @@ async fn test_worker_drain_state_transitions() {
         );
     }
 }
+
+// ============================================================================
+// Test 6: Deploy handler dispatch routes over NATS (C6a wiring regression)
+// ============================================================================
+//
+// Proves `Coordinator::execute_deploy_plan_dispatch` takes the NATS branch
+// when a client is configured. Workers are registered with `nats://...`
+// addresses, which reqwest CANNOT reach — so a Running placement can only
+// mean the command travelled over NATS. This is the handler-level routing
+// gap the raw `execute_deploy_plan_nats` test (`test_deploy_pipeline_group_
+// across_workers`) does not cover.
+//
+// Fail-before/pass-after gate: temporarily make the dispatch fn ignore its
+// `nats` argument and always call `execute_deploy_plan` (HTTP). Against the
+// `nats://w0` address the reqwest POST errors, the outcome is `Err`, the
+// placement is NOT `Running`, and this test FAILS — proving the NATS routing
+// is load-bearing. Restore the dispatch and it passes.
+//
+// Broker-skip: matches on `connect_nats` and early-returns with a `[skip]`
+// note (like `tests/chaos/network_partition.rs`) so CI without a broker stays
+// green.
+#[tokio::test]
+async fn test_deploy_dispatch_routes_over_nats() {
+    let client = match connect_nats(NATS_URL).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[skip] test_deploy_dispatch_routes_over_nats: NATS not reachable at {NATS_URL}: {e}"
+            );
+            return;
+        }
+    };
+
+    let coordinator = new_coordinator();
+
+    let w0_id = format!("disp-w0-{}", Uuid::new_v4());
+    let w1_id = format!("disp-w1-{}", Uuid::new_v4());
+    let w0_key = format!("key-{}", Uuid::new_v4());
+    let w1_key = format!("key-{}", Uuid::new_v4());
+
+    // Register workers with NATS addresses. `nats://...` is NOT a valid HTTP
+    // URL, so any HTTP fallback would fail — success proves NATS was used.
+    {
+        let mut coord = coordinator.write().await;
+        for (wid, key, addr) in [
+            (&w0_id, &w0_key, "nats://w0"),
+            (&w1_id, &w1_key, "nats://w1"),
+        ] {
+            let node = WorkerNode {
+                id: WorkerId(wid.clone()),
+                address: addr.to_string(),
+                api_key: SecretString::new(key.clone()),
+                status: WorkerStatus::Ready,
+                capacity: WorkerCapacity::default(),
+                last_heartbeat: std::time::Instant::now(),
+                assigned_pipelines: Vec::new(),
+                events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
+            };
+            coord.register_worker(node);
+        }
+    }
+
+    // TenantManagers + worker NATS handlers so the deploy commands land.
+    let tm0 = new_tenant_manager(&w0_key).await;
+    let tm1 = new_tenant_manager(&w1_key).await;
+
+    let h0 = {
+        let c = client.clone();
+        let wid = w0_id.clone();
+        let key = w0_key.clone();
+        let tm = tm0.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    let h1 = {
+        let c = client.clone();
+        let wid = w1_id.clone();
+        let key = w1_key.clone();
+        let tm = tm1.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let spec = PipelineGroupSpec {
+        name: "dispatch-deploy-test".to_string(),
+        pipelines: vec![
+            PipelinePlacement {
+                name: "pipe-a".to_string(),
+                source: "stream A = SensorReading .where(temperature > 100)".to_string(),
+                worker_affinity: Some(w0_id.clone()),
+                replicas: 1,
+                partition_key: None,
+            },
+            PipelinePlacement {
+                name: "pipe-b".to_string(),
+                source: "stream B = SensorReading .where(temperature > 50)".to_string(),
+                worker_affinity: Some(w1_id.clone()),
+                replicas: 1,
+                partition_key: None,
+            },
+        ],
+        routes: vec![],
+        region_affinity: None,
+        cross_region_routes: vec![],
+    };
+
+    // Phase 1: Plan.
+    let plan = {
+        let coord = coordinator.read().await;
+        coord.plan_deploy_group(&spec).unwrap()
+    };
+    assert_eq!(plan.tasks.len(), 2);
+
+    // Phase 2: dispatch WITH a NATS client. The `http` arg is a real client
+    // that would genuinely fail on the `nats://` addresses, so a Running
+    // result can only come from the NATS branch being taken.
+    let http = reqwest::Client::new();
+    let results = Coordinator::execute_deploy_plan_dispatch(Some(&client), &http, &plan).await;
+    assert_eq!(results.len(), 2);
+    for r in &results {
+        assert!(
+            r.outcome.is_ok(),
+            "deploy dispatch over NATS failed for {} (address {}): {:?}",
+            r.replica_name,
+            r.worker_address,
+            r.outcome
+        );
+    }
+
+    // Phase 3: Commit and assert EVERY placement is Running — the NATS branch
+    // worked end-to-end.
+    let group_id = {
+        let mut coord = coordinator.write().await;
+        coord.commit_deploy_group(plan, results).unwrap()
+    };
+    {
+        let coord = coordinator.read().await;
+        let group = coord.pipeline_groups.get(&group_id).expect("group missing");
+        assert_eq!(group.status, GroupStatus::Running);
+        assert_eq!(group.placements.len(), 2);
+        for (name, placement) in &group.placements {
+            assert_eq!(
+                placement.status,
+                PipelineDeploymentStatus::Running,
+                "placement '{name}' should be Running after NATS dispatch"
+            );
+        }
+    }
+
+    h0.abort();
+    h1.abort();
+}

--- a/crates/varpulis-connector-kafka/src/managed.rs
+++ b/crates/varpulis-connector-kafka/src/managed.rs
@@ -802,19 +802,30 @@ impl Sink for KafkaSharedSink {
                         .map_err(|_| SinkError::other("pending_offsets lock poisoned"))?;
                     std::mem::take(&mut *guard)
                 };
-                for (consumer, tpl) in &staged {
-                    let cgm = consumer
-                        .group_metadata()
-                        .ok_or_else(|| SinkError::other("consumer group_metadata unavailable"))?;
-                    self.producer
-                        .send_offsets_to_transaction(tpl, &cgm, Duration::from_secs(30))
-                        .map_err(|e| {
-                            SinkError::other(format!("send_offsets_to_transaction: {e}"))
+                // Send offsets + commit; on any failure restore the phase to 2
+                // (prepared) so the barrier's abort() actually aborts the still
+                // open transaction instead of no-op'ing on phase 0 (§7 hardening).
+                // These librdkafka calls are synchronous, so a plain closure with
+                // `?` captures the first error without crossing an await.
+                let outcome = (|| {
+                    for (consumer, tpl) in &staged {
+                        let cgm = consumer.group_metadata().ok_or_else(|| {
+                            SinkError::other("consumer group_metadata unavailable")
                         })?;
+                        self.producer
+                            .send_offsets_to_transaction(tpl, &cgm, Duration::from_secs(30))
+                            .map_err(|e| {
+                                SinkError::other(format!("send_offsets_to_transaction: {e}"))
+                            })?;
+                    }
+                    self.producer
+                        .commit_transaction(Duration::from_secs(30))
+                        .map_err(|e| SinkError::other(format!("commit_transaction: {e}")))
+                })();
+                if outcome.is_err() {
+                    state.phase.store(2, Ordering::SeqCst);
                 }
-                self.producer
-                    .commit_transaction(Duration::from_secs(30))
-                    .map_err(|e| SinkError::other(format!("commit_transaction: {e}")))?;
+                return outcome;
             }
         }
         Ok(())
@@ -822,6 +833,11 @@ impl Sink for KafkaSharedSink {
 
     async fn abort(&self, _checkpoint_id: u64) -> Result<(), SinkError> {
         if let Some(ref state) = self.txn_state {
+            // Discard any offsets staged for the aborted transaction so they
+            // don't leak into the next epoch.
+            if let Ok(mut guard) = state.pending_offsets.lock() {
+                guard.clear();
+            }
             if state.phase.swap(0, Ordering::SeqCst) > 0 {
                 self.producer
                     .abort_transaction(Duration::from_secs(10))

--- a/crates/varpulis-runtime/src/engine/barrier.rs
+++ b/crates/varpulis-runtime/src/engine/barrier.rs
@@ -146,9 +146,15 @@ impl Engine {
         // Phase 1b — persist checkpoint to disk (if checkpointing is enabled).
         // This must happen BEFORE the sink commit so that on crash-recovery the
         // restored engine state is consistent with the last committed offset.
+        //
+        // FATAL on failure: committing sinks/offsets on top of a state snapshot
+        // that never reached disk is the C3 loss in another dress. Abort the
+        // prepared sinks and return, leaving the committed frontier untouched.
         if self.has_checkpointing() {
             if let Err(e) = self.force_checkpoint() {
-                tracing::warn!("Checkpoint persist failed (epoch {checkpoint_id}): {e}");
+                tracing::error!("Checkpoint persist failed (epoch {checkpoint_id}): {e}");
+                self.abort_sinks(checkpoint_id).await;
+                return Err(BarrierError::Checkpoint(e.to_string()));
             }
         }
 
@@ -163,7 +169,14 @@ impl Engine {
             .any(|s| s.supports_exactly_once());
 
         // Phase 2 — prepare commit on transactional sinks (flush producer queues).
-        self.prepare_commit_sinks(checkpoint_id).await;
+        // On failure, abort the prepared sinks and return without committing —
+        // the committed frontier and source offsets stay untouched.
+        if !self.prepare_commit_sinks(checkpoint_id).await {
+            self.abort_sinks(checkpoint_id).await;
+            return Err(BarrierError::Sink(format!(
+                "prepare_commit failed for epoch {checkpoint_id}"
+            )));
+        }
 
         // C4 — exactly-once: stage the snapshot's source offsets so the sink
         // commit sends them inside its transaction. Output visibility and offset
@@ -186,7 +199,16 @@ impl Engine {
         // once the Kafka `commit_transaction` succeeds, downstream consumers can
         // see the emitted events. For exactly-once sinks this also commits the
         // staged source offsets atomically (they rode the same transaction).
-        self.commit_sinks(checkpoint_id).await;
+        //
+        // On failure, `commit_sinks` has NOT advanced the committed frontier or
+        // opened the next epoch; abort and return so a restart re-commits this
+        // epoch rather than skipping past it.
+        if !self.commit_sinks(checkpoint_id).await {
+            self.abort_sinks(checkpoint_id).await;
+            return Err(BarrierError::Sink(format!(
+                "commit failed for epoch {checkpoint_id}"
+            )));
+        }
 
         // Phase 4 — at-least-once path only: commit source offsets out-of-band
         // after the sink commit. For exactly-once the offsets already rode the
@@ -216,10 +238,21 @@ mod tests {
     use crate::sink::{Sink, SinkError};
 
     /// An exactly-once sink that records its 2PC lifecycle so a test can assert
-    /// the barrier drove the phases (and their order).
+    /// the barrier drove the phases (and their order). `fail_at` optionally
+    /// injects an error at a chosen phase ("prepare" or "commit").
     #[derive(Debug, Default)]
     struct TxnCaptureSink {
         lifecycle: Mutex<Vec<String>>,
+        fail_at: Option<&'static str>,
+    }
+
+    impl TxnCaptureSink {
+        fn failing_at(phase: &'static str) -> Self {
+            Self {
+                fail_at: Some(phase),
+                ..Default::default()
+            }
+        }
     }
 
     #[async_trait]
@@ -245,10 +278,16 @@ mod tests {
         }
         async fn prepare_commit(&self, id: u64) -> Result<(), SinkError> {
             self.lifecycle.lock().unwrap().push(format!("prepare:{id}"));
+            if self.fail_at == Some("prepare") {
+                return Err(SinkError::other("injected prepare failure"));
+            }
             Ok(())
         }
         async fn commit(&self, id: u64) -> Result<(), SinkError> {
             self.lifecycle.lock().unwrap().push(format!("commit:{id}"));
+            if self.fail_at == Some("commit") {
+                return Err(SinkError::other("injected commit failure"));
+            }
             Ok(())
         }
         async fn abort(&self, id: u64) -> Result<(), SinkError> {
@@ -582,6 +621,62 @@ mod tests {
             *out.lock().unwrap(),
             vec![0, 1, 2, 3, 4, 5, 0, 1, 2, 3, 4, 5],
             "split commit double-emits on crash — the bug C4 fixes"
+        );
+    }
+
+    /// Step 3 hardening — a failed sink commit must NOT advance the committed
+    /// epoch (the recovery marker that decides whether a re-commit is owed), the
+    /// barrier must surface the failure, and it must abort the prepared sinks.
+    ///
+    /// Fail-before: with the unguarded `commit_sinks` the epoch advances to the
+    /// failed checkpoint (5) even though the commit errored; without the barrier
+    /// check the barrier returns `Ok` and never aborts.
+    #[tokio::test]
+    async fn failed_commit_does_not_advance_epoch_and_aborts() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<Event>(16);
+        let mut engine = Engine::new(tx);
+
+        let sink = Arc::new(TxnCaptureSink::failing_at("commit"));
+        engine.inject_sink("out", sink.clone());
+        engine.begin_epoch_sinks(1).await;
+
+        engine.source_bindings.push(SourceBinding {
+            connector_name: "src".to_string(),
+            event_type: "E".to_string(),
+            topic_override: None,
+            extra_params: HashMap::new(),
+        });
+        engine
+            .source_offsets_handle()
+            .lock()
+            .unwrap()
+            .insert("src".to_string(), HashMap::from([(0, 7)]));
+
+        let epoch_before = engine.last_committed_epoch();
+        let coordinator = CaptureCoordinator::default();
+        let (_evt_tx, mut evt_rx) = tokio::sync::mpsc::channel::<Vec<Event>>(16);
+        let result = engine
+            .barrier_commit_2pc(5, &mut evt_rx, &coordinator)
+            .await;
+
+        assert!(result.is_err(), "barrier must surface the commit failure");
+        assert_eq!(
+            engine.last_committed_epoch(),
+            epoch_before,
+            "committed epoch must not advance when the commit failed"
+        );
+        assert_ne!(
+            engine.last_committed_epoch(),
+            5,
+            "the failed epoch must not be marked committed"
+        );
+        assert!(
+            sink.lifecycle
+                .lock()
+                .unwrap()
+                .contains(&"abort:5".to_string()),
+            "the barrier must abort the prepared sinks on commit failure: {:?}",
+            sink.lifecycle.lock().unwrap()
         );
     }
 }

--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -1283,39 +1283,58 @@ impl Engine {
     }
 
     /// Call `prepare_commit` on all exactly-once sinks for the given checkpoint epoch.
+    ///
+    /// Returns `false` if any sink's `prepare_commit` failed, so the barrier can
+    /// abort the epoch instead of committing on top of a half-prepared state.
     #[cfg(feature = "async-runtime")]
-    pub async fn prepare_commit_sinks(&self, checkpoint_id: u64) {
+    pub async fn prepare_commit_sinks(&self, checkpoint_id: u64) -> bool {
+        let mut all_ok = true;
         for (key, sink) in self.sinks.cache() {
             if sink.supports_exactly_once() {
                 if let Err(e) = sink.prepare_commit(checkpoint_id).await {
                     tracing::error!("Sink '{key}' prepare_commit failed: {e}");
+                    all_ok = false;
                 }
             }
         }
+        all_ok
     }
 
-    /// Call `commit` on all exactly-once sinks, then `begin_epoch` for the next epoch.
+    /// Call `commit` on all exactly-once sinks, then — only if every commit
+    /// succeeded — advance [`last_committed_epoch`](Self::last_committed_epoch)
+    /// and open the next epoch via `begin_epoch(id + 1)`.
     ///
-    /// Bumps [`last_committed_epoch`](Self::last_committed_epoch) to
-    /// `checkpoint_id` after the commit pass so recovery code (Task 3.2)
-    /// can detect whether a re-commit is still owed. The bump is monotonic:
-    /// out-of-order calls with a smaller `checkpoint_id` leave the marker
-    /// unchanged.
+    /// Returns `false` if any commit failed. On failure the committed frontier is
+    /// NOT advanced and the next epoch is NOT opened, so the caller can abort and
+    /// retry rather than silently committing past a failed sink. The bump is
+    /// monotonic: out-of-order calls with a smaller `checkpoint_id` leave the
+    /// marker unchanged.
     #[cfg(feature = "async-runtime")]
-    pub async fn commit_sinks(&self, checkpoint_id: u64) {
+    pub async fn commit_sinks(&self, checkpoint_id: u64) -> bool {
+        let mut all_ok = true;
         for (key, sink) in self.sinks.cache() {
             if sink.supports_exactly_once() {
                 if let Err(e) = sink.commit(checkpoint_id).await {
                     tracing::error!("Sink '{key}' commit failed: {e}");
+                    all_ok = false;
                 }
-                // Begin the next epoch immediately after commit
+            }
+        }
+        if !all_ok {
+            // A commit failed: do NOT advance the committed frontier or open the
+            // next epoch. The caller aborts and retries this epoch.
+            return false;
+        }
+        self.last_committed_epoch
+            .fetch_max(checkpoint_id, std::sync::atomic::Ordering::AcqRel);
+        for (key, sink) in self.sinks.cache() {
+            if sink.supports_exactly_once() {
                 if let Err(e) = sink.begin_epoch(checkpoint_id + 1).await {
                     tracing::error!("Sink '{key}' begin_epoch failed: {e}");
                 }
             }
         }
-        self.last_committed_epoch
-            .fetch_max(checkpoint_id, std::sync::atomic::Ordering::AcqRel);
+        true
     }
 
     /// Call `abort` on all exactly-once sinks (recovery path).


### PR DESCRIPTION
## What

**Audit critical C6 (part a) — the NATS outbound command path was dead.** `Coordinator.nats_client` was declared but **never assigned or read**: the CLI connected NATS and moved the client into the *inbound* handler task without storing it, so the deploy/teardown/inject REST handlers always used HTTP — even in a NATS deployment where worker addresses are `nats://...` (which HTTP can't reach). The `execute_*_nats` functions existed but were dead in production.

> Stacked on #191 (C5) — shares the new `WorkerNode` fields the test constructs. GitHub will retarget this to `main` when C5 merges.

## How

- **Store the client:** CLI startup now clones the connected client into `coord.nats_client` (the inbound handler keeps its own clone).
- **Testable dispatch:** new `execute_{deploy,teardown,inject}_*_dispatch(nats, http, ...)` fns pick the transport — `Some(nats) → *_nats`, else HTTP — so the routing is drivable without the Axum router.
- **Branch 3 handlers:** `handle_deploy_group` / `handle_delete_group` / `handle_inject_event` clone `coord.nats_client` in the read-lock plan phase and call the dispatch fn in the lock-free execute phase. The plan→IO→commit shape and Raft replication are untouched; **HTTP stays the default when `nats_client` is `None`**, so standalone/HTTP deployments are unchanged. Both feature arms (`nats-transport` on/off) compile.

## Test — REAL broker, fail-before / pass-after (no mocking)

`test_deploy_dispatch_routes_over_nats`: registers workers at `nats://w0`/`nats://w1` with **real worker NATS handlers**, then calls `execute_deploy_plan_dispatch(Some(&client), &http, &plan)` with a genuine reqwest client. A `Running` placement can **only** mean the command travelled over NATS — HTTP cannot reach a `nats://` address.

**Verified fail-before (independently, against the live broker):** forcing the dispatch to HTTP → `Err("builder error for url (nats://w0/api/v1/pipelines)")` → placement not `Running` → test fails. Restore → green.

Broker-skip-graceful (matches `connect_nats`, `[skip]` + early return like the chaos suite) so CI without a broker stays green.

`nats_multi_worker_e2e` **6/6** + `nats_cluster_e2e` **6/6** against real NATS; `raft_sim` **9/9** (C5 undisturbed); `make verify` green; `nats-transport` + `raft` feature clippy clean.

## C6 remaining
- [x] **C6a — deploy/teardown/inject wiring (this PR)**
- [ ] C6b — migrate-over-NATS (`execute_migrate_plan_nats` — new code; next)

🤖 Generated with [Claude Code](https://claude.com/claude-code)