### PR TITLE
ci: free disk space on heavy jobs to stop "No space left on device" flakes

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,32 @@
+name: Free disk space
+description: >
+  Reclaim disk on GitHub-hosted ubuntu-latest runners before a heavy build.
+  The runner ships with only ~14 GB free on /, which the full-workspace
+  all-targets build plus nextest/coverage test binaries can exhaust
+  ("No space left on device"). This deletes preinstalled language toolchains
+  that a Rust build never uses (~20-25 GB). Self-contained — no third-party
+  action, so nothing new enters the supply chain.
+runs:
+  using: composite
+  steps:
+    - name: Free disk space
+      shell: bash
+      run: |
+        echo "Disk before cleanup:"
+        df -h /
+        # Toolchains that are definitively unused by this Rust workspace.
+        # `|| true` so a missing path on a future runner image is not fatal.
+        sudo rm -rf \
+          /usr/share/dotnet \
+          /usr/local/lib/android \
+          /opt/ghc \
+          /usr/local/.ghcup \
+          /opt/hostedtoolcache/CodeQL \
+          /usr/local/share/boost \
+          /usr/local/graalvm \
+          /usr/local/share/powershell \
+          /usr/share/swift \
+          /usr/local/share/chromium \
+          /usr/local/lib/node_modules || true
+        echo "Disk after cleanup:"
+        df -h /

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@1.93
       - uses: Swatinem/rust-cache@v2
         with:
@@ -70,6 +71,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install connector system dependencies
@@ -83,6 +85,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
@@ -276,6 +279,7 @@ jobs:
           - all-connectors
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -333,6 +337,7 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
+      - uses: ./.github/actions/free-disk-space
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
## What

#190 and #191 failed their fast-gate **Test** job — not on code, but on the runner running out of disk mid-build:

```
Unhandled exception. System.IO.IOException: No space left on device
  : '/home/runner/actions-runner/.../_diag/Worker_...log'
```

The CI runners are **GitHub-hosted ephemeral** (every job is `runs-on: ubuntu-latest` — there's no self-hosted runner to clean), and they ship with only ~14 GB free on `/`. The full-workspace `--all-targets` build plus nextest/`llvm-cov` test binaries exhaust it. Rerunning lands on a fresh runner and usually passes — but the flake recurs (Coverage/MSRV/Test), so this is the durable fix.

## How

- New **self-contained** composite action `.github/actions/free-disk-space` that deletes preinstalled toolchains a Rust build never touches (dotnet, android, ghc, CodeQL, boost, graalvm, swift, …), reclaiming **~20–25 GB**. No third-party action — nothing new enters the supply chain (matches the audit's posture).
- Wired in right after `checkout` on the disk-heavy jobs: **test, check, msrv, coverage, feature-flags**.

The action prints `df -h /` before/after so the reclaimed space is visible in the logs. This PR's own Test run exercises it.

Unrelated to any code change — pure CI hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)