### PR TITLE
fix(cluster): NATS outbound command path — deploy/teardown/inject + migrate (audit C6)

### DIFF
--- a/crates/varpulis-cli/src/commands/coordinator.rs
+++ b/crates/varpulis-cli/src/commands/coordinator.rs
@@ -240,22 +240,29 @@ pub async fn run_coordinator(
 
     let coordinator = varpulis_cluster::shared_coordinator();
 
-    // Spawn NATS coordinator handler if NATS URL is configured
+    // Connect NATS and spawn the inbound coordinator handler if a NATS URL is
+    // configured. Keep a clone of the client so it can be stored on the
+    // coordinator below for the OUTBOUND command path (deploy/teardown/inject);
+    // the handler task gets its own clone.
     #[cfg(feature = "nats-transport")]
-    if let Some(ref nurl) = nats_url {
+    let coordinator_nats_client = if let Some(ref nurl) = nats_url {
         let nats_client = varpulis_cluster::nats_transport::connect_nats(nurl)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to connect to NATS: {}", e))?;
         info!("Coordinator connected to NATS at {}", nurl);
         let coord_for_nats = coordinator.clone();
+        let handler_client = nats_client.clone();
         tokio::spawn(async move {
             varpulis_cluster::nats_coordinator::run_coordinator_nats_handler(
-                nats_client,
+                handler_client,
                 coord_for_nats,
             )
             .await;
         });
-    }
+        Some(nats_client)
+    } else {
+        None
+    };
     #[cfg(not(feature = "nats-transport"))]
     let _ = &nats_url;
 
@@ -291,6 +298,13 @@ pub async fn run_coordinator(
                 peer_addrs: raft_peer_addrs_map.clone(),
                 admin_key: rbac.any_admin_key(),
             });
+        }
+
+        // Store the outbound NATS client so the deploy/teardown/inject REST
+        // handlers route commands over NATS (not HTTP) in a NATS deployment.
+        #[cfg(feature = "nats-transport")]
+        {
+            coord.nats_client = coordinator_nats_client;
         }
     }
 

--- a/crates/varpulis-cluster/src/api.rs
+++ b/crates/varpulis-cluster/src/api.rs
@@ -2227,38 +2227,82 @@ async fn handle_manual_migrate(
         return resp;
     }
 
-    // Phase 1: Plan (read lock — released before HTTP I/O)
-    let (plan, http_client, source_alive, connectors) = {
-        let coord = coordinator.read().await;
+    // Phase 1 (plan, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let (plan, result) = {
+        let (plan, http_client, source_alive, connectors, nats_client) = {
+            let coord = coordinator.read().await;
 
-        match coord.plan_migrate_pipeline(
-            &pipeline_name,
-            &group_id,
-            &WorkerId(body.target_worker_id),
-            MigrationReason::Manual,
-        ) {
-            Ok(plan) => {
-                let source_alive = coord
-                    .workers
-                    .get(&plan.source_worker_id)
-                    .map(|w| w.status != crate::worker::WorkerStatus::Unhealthy)
-                    .unwrap_or(false);
-                let connectors = coord.connectors.clone();
-                (plan, coord.http_client.clone(), source_alive, connectors)
+            match coord.plan_migrate_pipeline(
+                &pipeline_name,
+                &group_id,
+                &WorkerId(body.target_worker_id),
+                MigrationReason::Manual,
+            ) {
+                Ok(plan) => {
+                    let source_alive = coord
+                        .workers
+                        .get(&plan.source_worker_id)
+                        .map(|w| w.status != crate::worker::WorkerStatus::Unhealthy)
+                        .unwrap_or(false);
+                    let connectors = coord.connectors.clone();
+                    (
+                        plan,
+                        coord.http_client.clone(),
+                        source_alive,
+                        connectors,
+                        coord.nats_client.clone(),
+                    )
+                }
+                Err(e) => return cluster_error_response(e),
             }
-            Err(e) => return cluster_error_response(e),
-        }
+        };
+        // Read lock released here
+        let result = crate::coordinator::Coordinator::execute_migrate_plan_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &plan,
+            source_alive,
+            &connectors,
+            None,
+        )
+        .await;
+        (plan, result)
     };
-    // Read lock released here
+    #[cfg(not(feature = "nats-transport"))]
+    let (plan, result) = {
+        let (plan, http_client, source_alive, connectors) = {
+            let coord = coordinator.read().await;
 
-    // Phase 2: Execute HTTP steps (no lock held)
-    let result = crate::coordinator::Coordinator::execute_migrate_plan(
-        &http_client,
-        &plan,
-        source_alive,
-        &connectors,
-    )
-    .await;
+            match coord.plan_migrate_pipeline(
+                &pipeline_name,
+                &group_id,
+                &WorkerId(body.target_worker_id),
+                MigrationReason::Manual,
+            ) {
+                Ok(plan) => {
+                    let source_alive = coord
+                        .workers
+                        .get(&plan.source_worker_id)
+                        .map(|w| w.status != crate::worker::WorkerStatus::Unhealthy)
+                        .unwrap_or(false);
+                    let connectors = coord.connectors.clone();
+                    (plan, coord.http_client.clone(), source_alive, connectors)
+                }
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        let result = crate::coordinator::Coordinator::execute_migrate_plan(
+            &http_client,
+            &plan,
+            source_alive,
+            &connectors,
+        )
+        .await;
+        (plan, result)
+    };
 
     // Phase 3: Commit results (write lock)
     let mut coord = coordinator.write().await;

--- a/crates/varpulis-cluster/src/api.rs
+++ b/crates/varpulis-cluster/src/api.rs
@@ -868,19 +868,40 @@ async fn handle_deploy_group(
         return resp;
     }
 
-    // Phase 1: Plan (read lock — released before HTTP I/O)
-    let (plan, http_client) = {
-        let coord = coordinator.read().await;
-
-        match coord.plan_deploy_group(&body) {
-            Ok(plan) => (plan, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (plan, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let (plan, results) = {
+        let (plan, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_deploy_group(&body) {
+                Ok(plan) => (plan, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        let results = crate::coordinator::Coordinator::execute_deploy_plan_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &plan,
+        )
+        .await;
+        (plan, results)
     };
-    // Read lock released here
-
-    // Phase 2: Execute HTTP deploys (no lock held)
-    let results = crate::coordinator::Coordinator::execute_deploy_plan(&http_client, &plan).await;
+    #[cfg(not(feature = "nats-transport"))]
+    let (plan, results) = {
+        let (plan, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_deploy_group(&body) {
+                Ok(plan) => (plan, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        let results =
+            crate::coordinator::Coordinator::execute_deploy_plan(&http_client, &plan).await;
+        (plan, results)
+    };
 
     // Phase 3: Commit results (write lock)
     let mut coord = coordinator.write().await;
@@ -992,19 +1013,39 @@ async fn handle_delete_group(
         return resp;
     }
 
-    // Phase 1: Plan teardown under read lock
-    let (plan, http_client) = {
-        let coord = coordinator.read().await;
-
-        match coord.plan_teardown_group(&group_id) {
-            Ok(plan) => (plan, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (plan teardown, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let plan = {
+        let (plan, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_teardown_group(&group_id) {
+                Ok(plan) => (plan, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_teardown_plan_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &plan,
+        )
+        .await;
+        plan
     };
-    // Read lock released here
-
-    // Phase 2: Execute HTTP teardown without lock
-    crate::coordinator::Coordinator::execute_teardown_plan(&http_client, &plan).await;
+    #[cfg(not(feature = "nats-transport"))]
+    let plan = {
+        let (plan, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.plan_teardown_group(&group_id) {
+                Ok(plan) => (plan, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_teardown_plan(&http_client, &plan).await;
+        plan
+    };
 
     // Phase 3: Commit state changes under write lock
     let mut coord = coordinator.write().await;
@@ -1052,19 +1093,40 @@ async fn handle_inject_event(
     {
         return resp;
     }
-    // Phase 1: Resolve target under read lock
-    let (target, http_client) = {
-        let coord = coordinator.read().await;
-        match coord.resolve_inject_target(&group_id, &body) {
-            Ok(target) => (target, coord.http_client.clone()),
-            Err(e) => return cluster_error_response(e),
-        }
+    // Phase 1 (resolve target, read lock) + Phase 2 (execute, no lock).
+    // Transport is NATS when a client is configured, else HTTP (default).
+    #[cfg(feature = "nats-transport")]
+    let inject_result = {
+        let (target, http_client, nats_client) = {
+            let coord = coordinator.read().await;
+            match coord.resolve_inject_target(&group_id, &body) {
+                Ok(target) => (target, coord.http_client.clone(), coord.nats_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_inject_event_dispatch(
+            nats_client.as_ref(),
+            &http_client,
+            &target,
+            &body,
+        )
+        .await
     };
-    // Read lock released here
+    #[cfg(not(feature = "nats-transport"))]
+    let inject_result = {
+        let (target, http_client) = {
+            let coord = coordinator.read().await;
+            match coord.resolve_inject_target(&group_id, &body) {
+                Ok(target) => (target, coord.http_client.clone()),
+                Err(e) => return cluster_error_response(e),
+            }
+        };
+        // Read lock released here
+        crate::coordinator::Coordinator::execute_inject_event(&http_client, &target, &body).await
+    };
 
-    // Phase 2: Execute HTTP without lock
-    match crate::coordinator::Coordinator::execute_inject_event(&http_client, &target, &body).await
-    {
+    match inject_result {
         Ok(resp) => reply_json_status(&resp, StatusCode::OK),
         Err(e) => cluster_error_response(e),
     }

--- a/crates/varpulis-cluster/src/coordinator/deployment.rs
+++ b/crates/varpulis-cluster/src/coordinator/deployment.rs
@@ -251,6 +251,24 @@ impl Coordinator {
         results
     }
 
+    /// Execute a deployment plan over the best available transport.
+    ///
+    /// Routes over NATS request/reply when a NATS client is configured
+    /// (a NATS deployment, where worker addresses are `nats://...`), otherwise
+    /// falls back to HTTP. This is the single entry point the REST deploy
+    /// handler calls, so transport selection lives in exactly one place.
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_deploy_plan_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        plan: &DeployGroupPlan,
+    ) -> Vec<DeployTaskResult> {
+        match nats {
+            Some(n) => Self::execute_deploy_plan_nats(n, plan).await,
+            None => Self::execute_deploy_plan(http, plan).await,
+        }
+    }
+
     /// Phase 3: Commit deployment results to coordinator state.
     #[tracing::instrument(skip(self, plan, results), fields(group_id = %plan.group_id, group = %plan.spec.name))]
     pub fn commit_deploy_group(
@@ -726,6 +744,21 @@ impl Coordinator {
         }
     }
 
+    /// Execute a teardown plan over the best available transport.
+    ///
+    /// NATS when a client is configured, otherwise HTTP (unchanged default).
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_teardown_plan_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        plan: &TeardownPlan,
+    ) {
+        match nats {
+            Some(n) => Self::execute_teardown_plan_nats(n, plan).await,
+            None => Self::execute_teardown_plan(http, plan).await,
+        }
+    }
+
     /// Execute inject event via NATS request/reply.
     #[cfg(feature = "nats-transport")]
     pub async fn execute_inject_event_nats(
@@ -753,6 +786,22 @@ impl Coordinator {
             worker_id: target.worker_id.clone(),
             worker_response,
         })
+    }
+
+    /// Execute an inject event over the best available transport.
+    ///
+    /// NATS when a client is configured, otherwise HTTP (unchanged default).
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_inject_event_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        target: &InjectTarget,
+        event: &InjectEventRequest,
+    ) -> Result<InjectResponse, ClusterError> {
+        match nats {
+            Some(n) => Self::execute_inject_event_nats(n, target, event).await,
+            None => Self::execute_inject_event(http, target, event).await,
+        }
     }
 
     /// Convenience wrapper: resolve + execute inject event in one call.

--- a/crates/varpulis-cluster/src/coordinator/rebalance.rs
+++ b/crates/varpulis-cluster/src/coordinator/rebalance.rs
@@ -328,6 +328,203 @@ impl Coordinator {
         Self::execute_migrate_plan_inner(http_client, plan, source_alive, connectors, None).await
     }
 
+    /// NATS analogue of [`execute_migrate_plan_inner`] (audit C6b).
+    ///
+    /// There is no single worker `"migrate"` command — a migration is
+    /// *composed* of the primitive per-command NATS subjects the worker
+    /// already handles: `checkpoint` → `deploy` → `restore` → `undeploy`
+    /// (see `nats_worker.rs`). This mirrors the HTTP inner path's steps,
+    /// best-effort semantics (checkpoint + restore failures are non-fatal),
+    /// and return contract (`Ok(new_pipeline_id)` / `Err(reason)`), but
+    /// addresses each worker over NATS request/reply instead of HTTP. It is
+    /// the path that works in a NATS deployment, where worker addresses are
+    /// `nats://...` and reqwest cannot reach them.
+    ///
+    /// The distributed-checkpoint preference is preserved: a preloaded
+    /// `distributed_checkpoint` short-circuits the source checkpoint, which
+    /// is what makes failover work when the source worker is dead.
+    ///
+    /// Note the checkpoint envelope difference vs HTTP: the worker's
+    /// `checkpoint` handler replies with a *bare* `EngineCheckpoint` (the
+    /// HTTP route wraps it in a `CheckpointResponsePayload`), so
+    /// [`fetch_source_checkpoint_nats`] deserializes the reply directly.
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_migrate_plan_nats(
+        nats_client: &async_nats::Client,
+        plan: &MigratePipelinePlan,
+        source_alive: bool,
+        connectors: &HashMap<String, ClusterConnector>,
+        distributed_checkpoint: Option<EngineCheckpoint>,
+    ) -> Result<String, String> {
+        use crate::nats_transport;
+
+        let timeout = Duration::from_secs(10);
+
+        // Step 1: Acquire a checkpoint to restore on the target.
+        //
+        // Preference order mirrors `execute_migrate_plan_inner`:
+        //   1. A pre-loaded distributed checkpoint (durable state) — works
+        //      even when the source worker is dead.
+        //   2. Best-effort NATS checkpoint from the source worker.
+        //   3. Nothing — proceed with a stateless redeploy.
+        let checkpoint = if let Some(cp) = distributed_checkpoint {
+            info!(
+                "Using distributed checkpoint for pipeline '{}' migration to {} ({} events)",
+                plan.pipeline_name, plan.target_worker_id, cp.events_processed
+            );
+            Some(cp)
+        } else {
+            fetch_source_checkpoint_nats(nats_client, plan, source_alive, timeout).await
+        };
+
+        // Step 2: Deploy to target worker.
+        let (enriched_source, _) =
+            crate::connector_config::inject_connectors(&plan.vpl_source, connectors);
+
+        let deploy_subject = nats_transport::subject_cmd(&plan.target_worker_id.0, "deploy");
+        let deploy_body = serde_json::json!({
+            "name": plan.pipeline_name,
+            "source": enriched_source,
+        });
+
+        let new_pipeline_id = match nats_transport::nats_request::<_, DeployResponse>(
+            nats_client,
+            &deploy_subject,
+            &deploy_body,
+            timeout,
+        )
+        .await
+        {
+            Ok(resp_body) => {
+                info!(
+                    "Migration deploy over NATS: '{}' on target {} (id={}, status={})",
+                    resp_body.name, plan.target_worker_id, resp_body.id, resp_body.status
+                );
+                resp_body.id
+            }
+            Err(e) => {
+                return Err(format!("Deploy to target failed over NATS: {e}"));
+            }
+        };
+
+        // Step 3: Restore checkpoint on target (best-effort).
+        //
+        // The worker's `restore` handler reads the pipeline id from the
+        // request body (the HTTP route takes it in the URL), so we include
+        // it alongside the checkpoint.
+        if let Some(ref cp) = checkpoint {
+            let restore_subject = nats_transport::subject_cmd(&plan.target_worker_id.0, "restore");
+            let restore_body = serde_json::json!({
+                "pipeline_id": new_pipeline_id,
+                "checkpoint": cp,
+            });
+
+            match nats_transport::nats_request::<_, serde_json::Value>(
+                nats_client,
+                &restore_subject,
+                &restore_body,
+                timeout,
+            )
+            .await
+            {
+                Ok(resp) if resp.get("error").is_none() => {
+                    info!(
+                        "Checkpoint restored over NATS for pipeline '{}' on worker {}",
+                        plan.pipeline_name, plan.target_worker_id
+                    );
+                }
+                Ok(resp) => {
+                    warn!(
+                        "Restore failed over NATS for '{}' (continuing without state): {}",
+                        plan.pipeline_name, resp
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Restore request failed over NATS for '{}' (continuing without state): {}",
+                        plan.pipeline_name, e
+                    );
+                }
+            }
+        }
+
+        // Step 4: Cleanup — remove pipeline from source (skip if dead).
+        // Reuses the exact `undeploy` request shape from
+        // `execute_teardown_plan_nats` (`{ "pipeline_id": ... }`).
+        if source_alive && !plan.deployment.pipeline_id.is_empty() {
+            let undeploy_subject =
+                nats_transport::subject_cmd(&plan.source_worker_id.0, "undeploy");
+            let undeploy_body = serde_json::json!({
+                "pipeline_id": plan.deployment.pipeline_id,
+            });
+
+            match nats_transport::nats_request::<_, serde_json::Value>(
+                nats_client,
+                &undeploy_subject,
+                &undeploy_body,
+                timeout,
+            )
+            .await
+            {
+                Ok(_) => {
+                    info!(
+                        "Removed old pipeline '{}' from worker {} over NATS",
+                        plan.pipeline_name, plan.source_worker_id
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        "Failed to remove old pipeline '{}' from {} over NATS: {}",
+                        plan.pipeline_name, plan.source_worker_id, e
+                    );
+                }
+            }
+        }
+
+        Ok(new_pipeline_id)
+    }
+
+    /// Execute a migration plan over the best available transport (audit C6b).
+    ///
+    /// Routes over NATS request/reply when a NATS client is configured (a
+    /// NATS deployment, where worker addresses are `nats://...`), otherwise
+    /// falls back to the HTTP inner path. Mirrors the deploy/teardown/inject
+    /// `*_dispatch` helpers so transport selection for migration lives in
+    /// exactly one place. `distributed_checkpoint` is threaded through so a
+    /// failover caller can supply durable state when the source is dead.
+    #[cfg(feature = "nats-transport")]
+    pub async fn execute_migrate_plan_dispatch(
+        nats: Option<&async_nats::Client>,
+        http: &reqwest::Client,
+        plan: &MigratePipelinePlan,
+        source_alive: bool,
+        connectors: &HashMap<String, ClusterConnector>,
+        distributed_checkpoint: Option<EngineCheckpoint>,
+    ) -> Result<String, String> {
+        match nats {
+            Some(n) => {
+                Self::execute_migrate_plan_nats(
+                    n,
+                    plan,
+                    source_alive,
+                    connectors,
+                    distributed_checkpoint,
+                )
+                .await
+            }
+            None => {
+                Self::execute_migrate_plan_inner(
+                    http,
+                    plan,
+                    source_alive,
+                    connectors,
+                    distributed_checkpoint,
+                )
+                .await
+            }
+        }
+    }
+
     /// Variant of [`execute_migrate_plan`] that accepts a pre-loaded engine
     /// checkpoint sourced from the distributed checkpoint store.
     ///
@@ -1415,6 +1612,61 @@ async fn fetch_source_checkpoint(
         Err(e) => {
             warn!(
                 "Checkpoint request failed for '{}': {}",
+                plan.pipeline_name, e
+            );
+            None
+        }
+    }
+}
+
+/// NATS analogue of [`fetch_source_checkpoint`] (audit C6b): best-effort
+/// checkpoint of the source worker over NATS request/reply.
+///
+/// The worker's `checkpoint` handler replies with a *bare*
+/// `EngineCheckpoint` JSON — unlike the HTTP route, which wraps it in a
+/// `CheckpointResponsePayload` — so we deserialize the reply directly into
+/// an `EngineCheckpoint`. Any failure (source dead, request timeout, or an
+/// `{"error": ...}` reply that doesn't parse as a checkpoint) yields `None`
+/// so the caller proceeds with a stateless redeploy, matching the HTTP
+/// path's best-effort semantics.
+#[cfg(feature = "nats-transport")]
+async fn fetch_source_checkpoint_nats(
+    nats_client: &async_nats::Client,
+    plan: &MigratePipelinePlan,
+    source_alive: bool,
+    timeout: Duration,
+) -> Option<EngineCheckpoint> {
+    if !source_alive {
+        info!(
+            "Source worker {} is dead, proceeding without source checkpoint for '{}'",
+            plan.source_worker_id, plan.pipeline_name
+        );
+        return None;
+    }
+
+    let subject = crate::nats_transport::subject_cmd(&plan.source_worker_id.0, "checkpoint");
+    let body = serde_json::json!({
+        "pipeline_id": plan.deployment.pipeline_id,
+    });
+
+    match crate::nats_transport::nats_request::<_, EngineCheckpoint>(
+        nats_client,
+        &subject,
+        &body,
+        timeout,
+    )
+    .await
+    {
+        Ok(cp) => {
+            info!(
+                "Checkpoint captured over NATS for pipeline '{}' ({} events)",
+                plan.pipeline_name, cp.events_processed
+            );
+            Some(cp)
+        }
+        Err(e) => {
+            warn!(
+                "Checkpoint over NATS failed for '{}' (continuing without state): {}",
                 plan.pipeline_name, e
             );
             None

--- a/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
+++ b/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
@@ -25,7 +25,7 @@ use varpulis_cluster::nats_worker::run_worker_nats_handler;
 use varpulis_cluster::routing::{build_routing_table, event_type_matches};
 use varpulis_cluster::worker::{WorkerNode, WorkerStatus};
 use varpulis_cluster::{
-    DeployedPipelineGroup, GroupStatus, HeartbeatRequest, InterPipelineRoute,
+    DeployedPipelineGroup, GroupStatus, HeartbeatRequest, InterPipelineRoute, MigrationReason,
     PipelineDeploymentStatus, PipelineGroupSpec, PipelinePlacement, RegisterWorkerRequest,
     RegisterWorkerResponse, SharedCoordinator, WorkerCapacity, WorkerId,
 };
@@ -780,6 +780,244 @@ async fn test_deploy_dispatch_routes_over_nats() {
                 "placement '{name}' should be Running after NATS dispatch"
             );
         }
+    }
+
+    h0.abort();
+    h1.abort();
+}
+
+// ============================================================================
+// Test 7: Migrate handler dispatch routes over NATS (C6b — migrate-over-NATS)
+// ============================================================================
+//
+// Proves `Coordinator::execute_migrate_plan_dispatch` takes the NATS branch
+// (`execute_migrate_plan_nats`) when a client is configured, composing the
+// worker's primitive commands — checkpoint(source) -> deploy(target) ->
+// restore(target) -> undeploy(source) — over NATS. Both workers are
+// registered with `nats://...` addresses, which reqwest CANNOT reach, so a
+// pipeline that ends up Running on the target can only mean the migration
+// travelled over NATS. There is no `execute_migrate_plan_nats` regression
+// coverage otherwise — migrate had no NATS variant before C6b.
+//
+// Fail-before/pass-after gate: temporarily make `execute_migrate_plan_dispatch`
+// ignore its `nats` argument and always call `execute_migrate_plan_inner`
+// (HTTP). Against the `nats://w1` target address the reqwest deploy POST
+// errors, `execute_migrate_plan_inner` returns `Err`, the migration fails,
+// and the `result.is_ok()` assertion below FAILS — proving the NATS routing
+// is load-bearing. Restore the dispatch and it passes.
+//
+// Broker-skip: matches on `connect_nats` and early-returns with a `[skip]`
+// note (like `tests/chaos/network_partition.rs`) so CI without a broker stays
+// green.
+#[tokio::test]
+async fn test_migrate_dispatch_routes_over_nats() {
+    let client = match connect_nats(NATS_URL).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[skip] test_migrate_dispatch_routes_over_nats: NATS not reachable at {NATS_URL}: {e}"
+            );
+            return;
+        }
+    };
+
+    let coordinator = new_coordinator();
+
+    let w0_id = format!("mig-w0-{}", Uuid::new_v4());
+    let w1_id = format!("mig-w1-{}", Uuid::new_v4());
+    let w0_key = format!("key-{}", Uuid::new_v4());
+    let w1_key = format!("key-{}", Uuid::new_v4());
+
+    // Register both workers with NATS addresses. `nats://...` is NOT a valid
+    // HTTP URL, so any HTTP fallback would fail — success proves NATS was used.
+    {
+        let mut coord = coordinator.write().await;
+        for (wid, key, addr) in [
+            (&w0_id, &w0_key, "nats://w0"),
+            (&w1_id, &w1_key, "nats://w1"),
+        ] {
+            let node = WorkerNode {
+                id: WorkerId(wid.clone()),
+                address: addr.to_string(),
+                api_key: SecretString::new(key.clone()),
+                status: WorkerStatus::Ready,
+                capacity: WorkerCapacity::default(),
+                last_heartbeat: std::time::Instant::now(),
+                assigned_pipelines: Vec::new(),
+                events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
+            };
+            coord.register_worker(node);
+        }
+    }
+
+    // TenantManagers + worker NATS handlers so the commands land.
+    let tm0 = new_tenant_manager(&w0_key).await;
+    let tm1 = new_tenant_manager(&w1_key).await;
+
+    let h0 = {
+        let c = client.clone();
+        let wid = w0_id.clone();
+        let key = w0_key.clone();
+        let tm = tm0.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    let h1 = {
+        let c = client.clone();
+        let wid = w1_id.clone();
+        let key = w1_key.clone();
+        let tm = tm1.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // A real HTTP client, passed as the dispatch fallback. It would genuinely
+    // fail on the `nats://` worker addresses, so any success is NATS-only.
+    let http = reqwest::Client::new();
+
+    // --- Deploy pipe-a onto w0 (via the NATS deploy dispatch) -------------
+    let spec = PipelineGroupSpec {
+        name: "migrate-src-group".to_string(),
+        pipelines: vec![PipelinePlacement {
+            name: "pipe-a".to_string(),
+            source: "stream A = SensorReading .where(temperature > 100)".to_string(),
+            worker_affinity: Some(w0_id.clone()),
+            replicas: 1,
+            partition_key: None,
+        }],
+        routes: vec![],
+        region_affinity: None,
+        cross_region_routes: vec![],
+    };
+
+    let deploy_plan = {
+        let coord = coordinator.read().await;
+        coord.plan_deploy_group(&spec).unwrap()
+    };
+    let deploy_results =
+        Coordinator::execute_deploy_plan_dispatch(Some(&client), &http, &deploy_plan).await;
+    for r in &deploy_results {
+        assert!(
+            r.outcome.is_ok(),
+            "initial deploy over NATS failed for {}: {:?}",
+            r.replica_name,
+            r.outcome
+        );
+    }
+    let group_id = {
+        let mut coord = coordinator.write().await;
+        coord
+            .commit_deploy_group(deploy_plan, deploy_results)
+            .unwrap()
+    };
+
+    // Sanity: pipe-a is on w0's TenantManager, not w1's.
+    {
+        let mgr0 = tm0.read().await;
+        assert!(
+            mgr0.list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be deployed on w0 before migration"
+        );
+    }
+    {
+        let mgr1 = tm1.read().await;
+        assert!(
+            !mgr1
+                .list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should NOT be on w1 before migration"
+        );
+    }
+
+    // --- Migrate pipe-a from w0 -> w1 over NATS ---------------------------
+    // Phase 1: plan (read lock).
+    let (plan, source_alive, connectors) = {
+        let coord = coordinator.read().await;
+        let plan = coord
+            .plan_migrate_pipeline(
+                "pipe-a",
+                &group_id,
+                &WorkerId(w1_id.clone()),
+                MigrationReason::Manual,
+            )
+            .expect("plan_migrate_pipeline");
+        let source_alive = coord
+            .workers
+            .get(&plan.source_worker_id)
+            .map(|w| w.status != WorkerStatus::Unhealthy)
+            .unwrap_or(false);
+        (plan, source_alive, coord.connectors.clone())
+    };
+    // source is Ready, so the checkpoint step against w0 runs over NATS too.
+    assert!(source_alive, "source worker w0 should be alive");
+
+    // Phase 2: execute over the dispatch WITH a NATS client. Deploy targets
+    // `nats://w1`, so a successful new pipeline id can only come from NATS.
+    let result = Coordinator::execute_migrate_plan_dispatch(
+        Some(&client),
+        &http,
+        &plan,
+        source_alive,
+        &connectors,
+        None,
+    )
+    .await;
+    let new_pipeline_id = result
+        .as_ref()
+        .expect("migration over NATS should succeed")
+        .clone();
+    assert!(
+        !new_pipeline_id.is_empty(),
+        "migration should return a new pipeline id"
+    );
+
+    // Phase 3: commit.
+    {
+        let mut coord = coordinator.write().await;
+        coord.commit_migrate_pipeline(&plan, &new_pipeline_id, true, None);
+    }
+
+    // The placement now points at w1 and is Running.
+    {
+        let coord = coordinator.read().await;
+        let group = coord.pipeline_groups.get(&group_id).expect("group missing");
+        let placement = group.placements.get("pipe-a").expect("pipe-a placement");
+        assert_eq!(
+            placement.worker_id,
+            WorkerId(w1_id.clone()),
+            "pipe-a should now be placed on w1"
+        );
+        assert_eq!(placement.status, PipelineDeploymentStatus::Running);
+    }
+
+    // The pipeline is Running on w1's TenantManager (deployed over NATS)...
+    {
+        let mgr1 = tm1.read().await;
+        assert!(
+            mgr1.list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be Running on w1 after migration"
+        );
+    }
+    // ...and torn down on w0's TenantManager (undeployed over NATS).
+    {
+        let mgr0 = tm0.read().await;
+        assert!(
+            !mgr0
+                .list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be torn down on w0 after migration"
+        );
     }
 
     h0.abort();

--- a/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
+++ b/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
@@ -628,3 +628,160 @@ async fn test_worker_drain_state_transitions() {
         );
     }
 }
+
+// ============================================================================
+// Test 6: Deploy handler dispatch routes over NATS (C6a wiring regression)
+// ============================================================================
+//
+// Proves `Coordinator::execute_deploy_plan_dispatch` takes the NATS branch
+// when a client is configured. Workers are registered with `nats://...`
+// addresses, which reqwest CANNOT reach — so a Running placement can only
+// mean the command travelled over NATS. This is the handler-level routing
+// gap the raw `execute_deploy_plan_nats` test (`test_deploy_pipeline_group_
+// across_workers`) does not cover.
+//
+// Fail-before/pass-after gate: temporarily make the dispatch fn ignore its
+// `nats` argument and always call `execute_deploy_plan` (HTTP). Against the
+// `nats://w0` address the reqwest POST errors, the outcome is `Err`, the
+// placement is NOT `Running`, and this test FAILS — proving the NATS routing
+// is load-bearing. Restore the dispatch and it passes.
+//
+// Broker-skip: matches on `connect_nats` and early-returns with a `[skip]`
+// note (like `tests/chaos/network_partition.rs`) so CI without a broker stays
+// green.
+#[tokio::test]
+async fn test_deploy_dispatch_routes_over_nats() {
+    let client = match connect_nats(NATS_URL).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[skip] test_deploy_dispatch_routes_over_nats: NATS not reachable at {NATS_URL}: {e}"
+            );
+            return;
+        }
+    };
+
+    let coordinator = new_coordinator();
+
+    let w0_id = format!("disp-w0-{}", Uuid::new_v4());
+    let w1_id = format!("disp-w1-{}", Uuid::new_v4());
+    let w0_key = format!("key-{}", Uuid::new_v4());
+    let w1_key = format!("key-{}", Uuid::new_v4());
+
+    // Register workers with NATS addresses. `nats://...` is NOT a valid HTTP
+    // URL, so any HTTP fallback would fail — success proves NATS was used.
+    {
+        let mut coord = coordinator.write().await;
+        for (wid, key, addr) in [
+            (&w0_id, &w0_key, "nats://w0"),
+            (&w1_id, &w1_key, "nats://w1"),
+        ] {
+            let node = WorkerNode {
+                id: WorkerId(wid.clone()),
+                address: addr.to_string(),
+                api_key: SecretString::new(key.clone()),
+                status: WorkerStatus::Ready,
+                capacity: WorkerCapacity::default(),
+                last_heartbeat: std::time::Instant::now(),
+                assigned_pipelines: Vec::new(),
+                events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
+            };
+            coord.register_worker(node);
+        }
+    }
+
+    // TenantManagers + worker NATS handlers so the deploy commands land.
+    let tm0 = new_tenant_manager(&w0_key).await;
+    let tm1 = new_tenant_manager(&w1_key).await;
+
+    let h0 = {
+        let c = client.clone();
+        let wid = w0_id.clone();
+        let key = w0_key.clone();
+        let tm = tm0.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    let h1 = {
+        let c = client.clone();
+        let wid = w1_id.clone();
+        let key = w1_key.clone();
+        let tm = tm1.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    let spec = PipelineGroupSpec {
+        name: "dispatch-deploy-test".to_string(),
+        pipelines: vec![
+            PipelinePlacement {
+                name: "pipe-a".to_string(),
+                source: "stream A = SensorReading .where(temperature > 100)".to_string(),
+                worker_affinity: Some(w0_id.clone()),
+                replicas: 1,
+                partition_key: None,
+            },
+            PipelinePlacement {
+                name: "pipe-b".to_string(),
+                source: "stream B = SensorReading .where(temperature > 50)".to_string(),
+                worker_affinity: Some(w1_id.clone()),
+                replicas: 1,
+                partition_key: None,
+            },
+        ],
+        routes: vec![],
+        region_affinity: None,
+        cross_region_routes: vec![],
+    };
+
+    // Phase 1: Plan.
+    let plan = {
+        let coord = coordinator.read().await;
+        coord.plan_deploy_group(&spec).unwrap()
+    };
+    assert_eq!(plan.tasks.len(), 2);
+
+    // Phase 2: dispatch WITH a NATS client. The `http` arg is a real client
+    // that would genuinely fail on the `nats://` addresses, so a Running
+    // result can only come from the NATS branch being taken.
+    let http = reqwest::Client::new();
+    let results = Coordinator::execute_deploy_plan_dispatch(Some(&client), &http, &plan).await;
+    assert_eq!(results.len(), 2);
+    for r in &results {
+        assert!(
+            r.outcome.is_ok(),
+            "deploy dispatch over NATS failed for {} (address {}): {:?}",
+            r.replica_name,
+            r.worker_address,
+            r.outcome
+        );
+    }
+
+    // Phase 3: Commit and assert EVERY placement is Running — the NATS branch
+    // worked end-to-end.
+    let group_id = {
+        let mut coord = coordinator.write().await;
+        coord.commit_deploy_group(plan, results).unwrap()
+    };
+    {
+        let coord = coordinator.read().await;
+        let group = coord.pipeline_groups.get(&group_id).expect("group missing");
+        assert_eq!(group.status, GroupStatus::Running);
+        assert_eq!(group.placements.len(), 2);
+        for (name, placement) in &group.placements {
+            assert_eq!(
+                placement.status,
+                PipelineDeploymentStatus::Running,
+                "placement '{name}' should be Running after NATS dispatch"
+            );
+        }
+    }
+
+    h0.abort();
+    h1.abort();
+}


### PR DESCRIPTION
## What

**Audit critical C6 — NATS outbound command path dead.** `Coordinator.nats_client` was declared but never assigned or read, so every deploy/teardown/inject/migrate REST handler used HTTP even in a NATS deployment (worker addresses `nats://...`, unreachable by HTTP). The `execute_*_nats` functions existed but were dead in production; migrate had no NATS variant at all.

This is the clean, linear landing of **C6a + C6b** (the earlier stacked PRs #192/#194 merged into their intermediate base branches rather than main; identical net diff, re-verified).

## How

- **Store the client** at CLI startup into `coord.nats_client` (inbound handler keeps its own clone).
- **Testable dispatch fns** `execute_{deploy,teardown,inject,migrate}_*_dispatch(nats, http, ...)` — `Some(nats) → *_nats`, else HTTP.
- **`execute_migrate_plan_nats`** composes checkpoint→deploy→restore(best-effort)→undeploy over the existing worker NATS subjects (feasibility verified: no worker-side change needed; the composer deserializes the bare `EngineCheckpoint` the NATS handler returns), preserving the distributed-checkpoint short-circuit.
- **Branch the 4 REST handlers** (deploy/teardown/inject/migrate) on `nats_client`; plan→lock-free-IO→commit + Raft replication untouched; **HTTP stays the default when `nats_client` is None**, so standalone/HTTP deployments are unchanged. All feature combos (`nats-transport` on/off, `raft` on/off) compile.

## Tests — REAL NATS broker, fail-before/pass-after (no mocking)

Two non-ignored, broker-skip-graceful e2e tests, both **re-verified independently against a live broker**:
- `test_deploy_dispatch_routes_over_nats` — deploy routes over NATS to a `nats://` worker; forcing HTTP → `builder error for url (nats://w0/...)` → not `Running`.
- `test_migrate_dispatch_routes_over_nats` — deploy to `w0`, migrate to `w1`, land Running on w1 + torn down on w0; forcing HTTP → migrate fails on `nats://w1/...`.

`nats_multi_worker_e2e` **7/7** + `nats_cluster_e2e` **6/6** + `raft_sim` **9/9**; `make verify` green; `nats-transport` + `raft` feature clippy clean.

## Follow-up (documented, not blocking)

The **auto-failover** path (`Coordinator::migrate_pipeline`, used by `handle_worker_failure`/`drain`/`rebalance`) is still HTTP-only; routing it through `execute_migrate_plan_dispatch` closes NATS failover (and the C5-triggered-migration hazard). The building block is now in place.

## Criticals: 6 of 6

C1 ✅ · C2 ✅ · C3 ✅ · C4 ✅ · C5 ✅ · **C6 ✅ (this PR)** — the entire 2026-07-15 audit critical set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)