### PR TITLE
fix(cluster): route auto-failover pipeline migration over NATS (C6 follow-up)

### DIFF
--- a/crates/varpulis-cluster/src/coordinator/rebalance.rs
+++ b/crates/varpulis-cluster/src/coordinator/rebalance.rs
@@ -695,7 +695,14 @@ impl Coordinator {
 
     /// Migrate a pipeline from its current worker to a target worker.
     ///
-    /// Steps: checkpoint (if source alive) -> deploy -> restore -> switch -> cleanup.
+    /// Plan (lookups, no I/O) -> execute over the best available transport ->
+    /// commit. The execute step routes over NATS when a NATS client is
+    /// configured (worker addresses are `nats://...`), otherwise HTTP — the
+    /// same `execute_migrate_plan_dispatch` the manual REST migrate handler
+    /// uses. This is the audit-C6 follow-up: a C5-triggered auto-failover (and
+    /// drain / rebalance, which also funnel through here) must migrate over
+    /// NATS in a NATS deployment instead of POSTing to an unreachable
+    /// `nats://` worker address.
     #[tracing::instrument(skip(self), fields(pipeline = %pipeline_name, group = %group_id, target = %target_worker_id))]
     pub async fn migrate_pipeline(
         &mut self,
@@ -704,314 +711,63 @@ impl Coordinator {
         target_worker_id: &WorkerId,
         reason: MigrationReason,
     ) -> Result<String, ClusterError> {
-        let migrate_start = Instant::now();
-        let group = self
-            .pipeline_groups
-            .get(group_id)
-            .ok_or_else(|| ClusterError::GroupNotFound(group_id.to_string()))?;
+        // Phase 1: Build the migration plan (lookups only, no I/O). Errors here
+        // (missing group / pipeline / target worker / VPL source) surface before
+        // any state mutation, exactly as the old inline path did.
+        let plan = self.plan_migrate_pipeline(pipeline_name, group_id, target_worker_id, reason)?;
+        let source_worker_id = plan.source_worker_id.clone();
 
-        let deployment = group
-            .placements
-            .get(pipeline_name)
-            .ok_or_else(|| {
-                ClusterError::MigrationFailed(format!(
-                    "Pipeline '{}' not found in group '{}'",
-                    pipeline_name, group_id
-                ))
-            })?
-            .clone();
-
-        let source_worker_id = deployment.worker_id.clone();
-
-        let target_worker = self
-            .workers
-            .get(target_worker_id)
-            .ok_or_else(|| ClusterError::WorkerNotFound(target_worker_id.0.clone()))?;
-        let target_address = target_worker.address.clone();
-        let target_api_key = target_worker.api_key.expose().to_string();
-
-        let migration_id = uuid::Uuid::new_v4().to_string();
-
-        let mut task = MigrationTask {
-            id: migration_id.clone(),
-            pipeline_name: pipeline_name.to_string(),
-            group_id: group_id.to_string(),
-            source_worker: source_worker_id.clone(),
-            target_worker: target_worker_id.clone(),
-            status: MigrationStatus::Checkpointing,
-            started_at: Instant::now(),
-            checkpoint: None,
-            reason,
-        };
-
-        self.active_migrations
-            .insert(migration_id.clone(), task.clone());
-
-        // Step 1: Checkpoint (best-effort -- skip if source is dead)
-        let checkpoint = if self
-            .workers
-            .get(&source_worker_id)
-            .map(|w| w.status != WorkerStatus::Unhealthy)
-            .unwrap_or(false)
-        {
-            let checkpoint_url = format!(
-                "{}/api/v1/pipelines/{}/checkpoint",
-                deployment.worker_address, deployment.pipeline_id
-            );
-            match self
-                .http_client
-                .post(&checkpoint_url)
-                .header("x-api-key", &deployment.worker_api_key)
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    match resp.json::<CheckpointResponsePayload>().await {
-                        Ok(cp_resp) => {
-                            info!(
-                                "Checkpoint captured for pipeline '{}' (id={}, {} events)",
-                                pipeline_name, cp_resp.pipeline_id, cp_resp.events_processed
-                            );
-                            Some(cp_resp.checkpoint)
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to deserialize checkpoint for '{}': {}",
-                                pipeline_name, e
-                            );
-                            None
-                        }
-                    }
-                }
-                Ok(resp) => {
-                    warn!(
-                        "Checkpoint HTTP error for '{}': {}",
-                        pipeline_name,
-                        resp.status()
-                    );
-                    None
-                }
-                Err(e) => {
-                    warn!("Checkpoint request failed for '{}': {}", pipeline_name, e);
-                    None
-                }
-            }
-        } else {
-            info!(
-                "Source worker {} is dead, proceeding without checkpoint for '{}'",
-                source_worker_id, pipeline_name
-            );
-            None
-        };
-
-        task.checkpoint = checkpoint.clone();
-
-        // Step 2: Deploy to target worker
-        task.status = MigrationStatus::Deploying;
-        self.active_migrations
-            .insert(migration_id.clone(), task.clone());
-
-        // Find the pipeline's VPL source from the group spec.
-        // For replicas like "p1#0", extract logical name "p1" for the lookup.
-        let logical_name = pipeline_name
-            .rsplit_once('#')
-            .map(|(base, _)| base)
-            .unwrap_or(pipeline_name);
-
-        let vpl_source = group
-            .spec
-            .pipelines
-            .iter()
-            .find(|p| p.name == logical_name)
-            .map(|p| p.source.clone())
-            .ok_or_else(|| {
-                ClusterError::MigrationFailed(format!(
-                    "VPL source not found for '{}'",
-                    pipeline_name
-                ))
-            })?;
-
-        let (enriched_source, _) =
-            crate::connector_config::inject_connectors(&vpl_source, &self.connectors);
-
-        let deploy_url = format!("{}/api/v1/pipelines", target_address);
-        let deploy_body = serde_json::json!({
-            "name": pipeline_name,
-            "source": enriched_source,
-        });
-
-        let new_pipeline_id = match self
-            .http_client
-            .post(&deploy_url)
-            .header("x-api-key", &target_api_key)
-            .json(&deploy_body)
-            .send()
-            .await
-        {
-            Ok(resp) if resp.status().is_success() => {
-                let resp_body: DeployResponse = resp
-                    .json()
-                    .await
-                    .map_err(|e| ClusterError::MigrationFailed(e.to_string()))?;
-                info!(
-                    "Migration deploy: '{}' on target {} (id={}, status={})",
-                    resp_body.name, target_worker_id, resp_body.id, resp_body.status
-                );
-                resp_body.id
-            }
-            Ok(resp) => {
-                let body = resp.text().await.unwrap_or_default();
-                task.status = MigrationStatus::Failed(format!("Deploy failed: {}", body));
-                self.active_migrations.insert(migration_id.clone(), task);
-                self.cluster_metrics
-                    .record_migration(false, migrate_start.elapsed().as_secs_f64());
-                return Err(ClusterError::MigrationFailed(format!(
-                    "Deploy to target failed: {}",
-                    body
-                )));
-            }
-            Err(e) => {
-                task.status = MigrationStatus::Failed(format!("Deploy request failed: {}", e));
-                self.active_migrations.insert(migration_id.clone(), task);
-                self.cluster_metrics
-                    .record_migration(false, migrate_start.elapsed().as_secs_f64());
-                return Err(ClusterError::MigrationFailed(e.to_string()));
-            }
-        };
-
-        // Step 3: Restore checkpoint on target
-        if let Some(ref cp) = checkpoint {
-            task.status = MigrationStatus::Restoring;
-            self.active_migrations
-                .insert(migration_id.clone(), task.clone());
-
-            let restore_url = format!(
-                "{}/api/v1/pipelines/{}/restore",
-                target_address, new_pipeline_id
-            );
-            let restore_body = serde_json::json!({ "checkpoint": cp });
-
-            match self
-                .http_client
-                .post(&restore_url)
-                .header("x-api-key", &target_api_key)
-                .json(&restore_body)
-                .send()
-                .await
-            {
-                Ok(resp) if resp.status().is_success() => {
-                    info!(
-                        "Checkpoint restored for pipeline '{}' on worker {}",
-                        pipeline_name, target_worker_id
-                    );
-                }
-                Ok(resp) => {
-                    let body = resp.text().await.unwrap_or_default();
-                    warn!(
-                        "Restore failed for '{}' (continuing without state): {}",
-                        pipeline_name, body
-                    );
-                }
-                Err(e) => {
-                    warn!(
-                        "Restore request failed for '{}' (continuing without state): {}",
-                        pipeline_name, e
-                    );
-                }
-            }
-        }
-
-        // Step 4: Switch -- update placements to point to target
-        task.status = MigrationStatus::Switching;
-        self.active_migrations
-            .insert(migration_id.clone(), task.clone());
-
-        if let Some(group) = self.pipeline_groups.get_mut(group_id) {
-            let new_epoch = group
-                .placements
-                .get(pipeline_name)
-                .map(|d| d.epoch + 1)
-                .unwrap_or(1);
-            group.placements.insert(
-                pipeline_name.to_string(),
-                PipelineDeployment {
-                    worker_id: target_worker_id.clone(),
-                    worker_address: target_address,
-                    worker_api_key: target_api_key,
-                    pipeline_id: new_pipeline_id,
-                    status: PipelineDeploymentStatus::Running,
-                    epoch: new_epoch,
-                },
-            );
-            group.update_status();
-        }
-
-        // Update worker bookkeeping
-        if let Some(w) = self.workers.get_mut(target_worker_id) {
-            w.assigned_pipelines.push(pipeline_name.to_string());
-            w.capacity.pipelines_running += 1;
-        }
-
-        // Step 5: Cleanup -- remove pipeline from source (skip if dead)
-        task.status = MigrationStatus::CleaningUp;
-        self.active_migrations
-            .insert(migration_id.clone(), task.clone());
-
+        // A source worker that is still registered and not explicitly Unhealthy
+        // is treated as reachable for the best-effort checkpoint step; when it
+        // is dead we skip straight to a stateless redeploy. Same predicate the
+        // manual REST migrate handler uses.
         let source_alive = self
             .workers
             .get(&source_worker_id)
             .map(|w| w.status != WorkerStatus::Unhealthy)
             .unwrap_or(false);
 
-        if source_alive && !deployment.pipeline_id.is_empty() {
-            let delete_url = format!(
-                "{}/api/v1/pipelines/{}",
-                deployment.worker_address, deployment.pipeline_id
-            );
-            match self
-                .http_client
-                .delete(&delete_url)
-                .header("x-api-key", &deployment.worker_api_key)
-                .send()
-                .await
-            {
-                Ok(_) => {
-                    info!(
-                        "Removed old pipeline '{}' from worker {}",
-                        pipeline_name, source_worker_id
-                    );
+        // Phase 2: Execute over the best available transport — NATS when a
+        // client is configured, otherwise HTTP. `distributed_checkpoint` is
+        // threaded through as `None` here (the internal failover / drain /
+        // rebalance path has no preloaded durable snapshot to hand off); the
+        // dead-source short-circuit is driven by `source_alive`, so a dead
+        // source still migrates statelessly rather than blocking on an
+        // unreachable worker.
+        #[cfg(feature = "nats-transport")]
+        let result = Self::execute_migrate_plan_dispatch(
+            self.nats_client.as_ref(),
+            &self.http_client,
+            &plan,
+            source_alive,
+            &self.connectors,
+            None,
+        )
+        .await;
+        #[cfg(not(feature = "nats-transport"))]
+        let result =
+            Self::execute_migrate_plan(&self.http_client, &plan, source_alive, &self.connectors)
+                .await;
+
+        // Phase 3: Commit results to coordinator state.
+        match result {
+            Ok(new_pipeline_id) => {
+                let migration_id =
+                    self.commit_migrate_pipeline(&plan, &new_pipeline_id, true, None);
+                // Clear stale metrics for the migrated pipeline on the source
+                // worker. `commit_migrate_pipeline` handles placement + worker
+                // bookkeeping; this source-metric purge is unique to the
+                // internal path and is preserved from the old inline flow.
+                if let Some(wm) = self.worker_metrics.get_mut(&source_worker_id) {
+                    wm.retain(|m| m.pipeline_name != *pipeline_name);
                 }
-                Err(e) => {
-                    warn!(
-                        "Failed to remove old pipeline '{}' from {}: {}",
-                        pipeline_name, source_worker_id, e
-                    );
-                }
+                Ok(migration_id)
+            }
+            Err(reason) => {
+                self.commit_migrate_pipeline(&plan, "", false, Some(reason.clone()));
+                Err(ClusterError::MigrationFailed(reason))
             }
         }
-
-        if let Some(w) = self.workers.get_mut(&source_worker_id) {
-            w.assigned_pipelines.retain(|p| p != pipeline_name);
-            w.capacity.pipelines_running = w.capacity.pipelines_running.saturating_sub(1);
-        }
-        // Clear stale metrics for the migrated pipeline on the source worker.
-        if let Some(wm) = self.worker_metrics.get_mut(&source_worker_id) {
-            wm.retain(|m| m.pipeline_name != *pipeline_name);
-        }
-
-        task.status = MigrationStatus::Completed;
-        self.active_migrations.insert(migration_id.clone(), task);
-
-        self.cluster_metrics
-            .record_migration(true, migrate_start.elapsed().as_secs_f64());
-        self.update_metrics_counts();
-
-        info!(
-            "Migration complete: pipeline '{}' moved from {} to {}",
-            pipeline_name, source_worker_id, target_worker_id
-        );
-
-        Ok(migration_id)
     }
 
     /// Handle a worker failure: migrate all its pipelines to healthy workers.

--- a/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
+++ b/crates/varpulis-cluster/tests/nats_multi_worker_e2e.rs
@@ -1023,3 +1023,226 @@ async fn test_migrate_dispatch_routes_over_nats() {
     h0.abort();
     h1.abort();
 }
+
+// ============================================================================
+// Test 8: Auto-failover migrate routes over NATS (audit C6 follow-up, C5→C6)
+// ============================================================================
+//
+// The gap C6 left open: `Coordinator::migrate_pipeline` — the INTERNAL caller
+// behind `handle_worker_failure` / `drain_worker` / `rebalance` — POSTed over
+// HTTP even in a NATS deployment. A C5-triggered auto-failover would then try
+// to reach a `nats://` worker address with reqwest and fail. This test drives
+// the REAL failover entry point, `Coordinator::handle_worker_failure`, with a
+// NATS client configured on the coordinator and both workers addressed as
+// `nats://...` (unreachable by reqwest). A pipeline that ends up Running on the
+// target can only mean the failover migration travelled over NATS.
+//
+// Unlike Test 7 — which calls `execute_migrate_plan_dispatch` directly with an
+// explicit `Some(&client)` — this exercises the internal path end to end: the
+// coordinator must pick the transport up from its own `nats_client` field.
+//
+// Fail-before / pass-after gate: in `migrate_pipeline`, flip
+// `self.nats_client.as_ref()` to `None` in the `execute_migrate_plan_dispatch`
+// call. The failover then routes over HTTP, the deploy POST to `nats://w1`
+// errors, `execute_migrate_plan_inner` returns `Err`, the migration fails, the
+// placement stays on w0, and the "failed over to w1" assertions below FAIL.
+// Restore `self.nats_client.as_ref()` and it passes. `handle_worker_failure`
+// swallows per-pipeline errors into its returned Vec, so the load-bearing
+// assertions are on placement STATE, not on the return value.
+//
+// Broker-skip: matches on `connect_nats` and early-returns with a `[skip]`
+// note (like `tests/chaos/network_partition.rs`) so CI without a broker stays
+// green.
+#[tokio::test]
+async fn test_auto_failover_migrate_routes_over_nats() {
+    let client = match connect_nats(NATS_URL).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!(
+                "[skip] test_auto_failover_migrate_routes_over_nats: NATS not reachable at {NATS_URL}: {e}"
+            );
+            return;
+        }
+    };
+
+    let coordinator = new_coordinator();
+
+    let w0_id = format!("fo-w0-{}", Uuid::new_v4());
+    let w1_id = format!("fo-w1-{}", Uuid::new_v4());
+    let w0_key = format!("key-{}", Uuid::new_v4());
+    let w1_key = format!("key-{}", Uuid::new_v4());
+
+    // Register both workers with NATS addresses AND set the coordinator's NATS
+    // client. `migrate_pipeline` reads `self.nats_client`, so configuring it is
+    // exactly what makes the internal failover path route over NATS. `nats://`
+    // is not a valid HTTP URL, so any HTTP fallback would fail — success proves
+    // the NATS transport was used.
+    {
+        let mut coord = coordinator.write().await;
+        coord.nats_client = Some(client.clone());
+        for (wid, key, addr) in [
+            (&w0_id, &w0_key, "nats://w0"),
+            (&w1_id, &w1_key, "nats://w1"),
+        ] {
+            let node = WorkerNode {
+                id: WorkerId(wid.clone()),
+                address: addr.to_string(),
+                api_key: SecretString::new(key.clone()),
+                status: WorkerStatus::Ready,
+                capacity: WorkerCapacity::default(),
+                last_heartbeat: std::time::Instant::now(),
+                assigned_pipelines: Vec::new(),
+                events_processed: 0,
+                heartbeat_seq: 0,
+                last_seen_hb_seq: 0,
+            };
+            coord.register_worker(node);
+        }
+    }
+
+    // TenantManagers + worker NATS handlers so the failover commands land.
+    let tm0 = new_tenant_manager(&w0_key).await;
+    let tm1 = new_tenant_manager(&w1_key).await;
+
+    let h0 = {
+        let c = client.clone();
+        let wid = w0_id.clone();
+        let key = w0_key.clone();
+        let tm = tm0.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    let h1 = {
+        let c = client.clone();
+        let wid = w1_id.clone();
+        let key = w1_key.clone();
+        let tm = tm1.clone();
+        tokio::spawn(async move {
+            run_worker_nats_handler(c, &wid, &key, tm).await;
+        })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // A real HTTP client as the dispatch fallback — it would genuinely fail on
+    // the `nats://` worker addresses, so any success is NATS-only.
+    let http = reqwest::Client::new();
+
+    // --- Deploy pipe-a onto w0 (via the NATS deploy dispatch) -------------
+    let spec = PipelineGroupSpec {
+        name: "failover-src-group".to_string(),
+        pipelines: vec![PipelinePlacement {
+            name: "pipe-a".to_string(),
+            source: "stream A = SensorReading .where(temperature > 100)".to_string(),
+            worker_affinity: Some(w0_id.clone()),
+            replicas: 1,
+            partition_key: None,
+        }],
+        routes: vec![],
+        region_affinity: None,
+        cross_region_routes: vec![],
+    };
+
+    let deploy_plan = {
+        let coord = coordinator.read().await;
+        coord.plan_deploy_group(&spec).unwrap()
+    };
+    let deploy_results =
+        Coordinator::execute_deploy_plan_dispatch(Some(&client), &http, &deploy_plan).await;
+    for r in &deploy_results {
+        assert!(
+            r.outcome.is_ok(),
+            "initial deploy over NATS failed for {}: {:?}",
+            r.replica_name,
+            r.outcome
+        );
+    }
+    let group_id = {
+        let mut coord = coordinator.write().await;
+        coord
+            .commit_deploy_group(deploy_plan, deploy_results)
+            .unwrap()
+    };
+
+    // Sanity: pipe-a is placed on w0 and Running on w0's TenantManager.
+    {
+        let coord = coordinator.read().await;
+        let placement = coord.pipeline_groups[&group_id]
+            .placements
+            .get("pipe-a")
+            .expect("pipe-a placement");
+        assert_eq!(
+            placement.worker_id,
+            WorkerId(w0_id.clone()),
+            "pipe-a should start on w0"
+        );
+    }
+    {
+        let mgr0 = tm0.read().await;
+        assert!(
+            mgr0.list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be deployed on w0 before failover"
+        );
+    }
+
+    // --- Trigger the REAL failover entry point ----------------------------
+    // `handle_worker_failure` finds pipe-a on w0 and migrates it to the only
+    // other available worker (w1). It calls `migrate_pipeline` internally,
+    // which must route over NATS because `coord.nats_client` is set.
+    let failover_results = {
+        let mut coord = coordinator.write().await;
+        coord.handle_worker_failure(&WorkerId(w0_id.clone())).await
+    };
+    assert_eq!(
+        failover_results.len(),
+        1,
+        "exactly one pipeline (pipe-a) should have been handled by the failover"
+    );
+
+    // Assert on STATE (not just the return): the placement now points at w1 and
+    // is Running. Over `nats://` addresses this is only reachable via NATS.
+    {
+        let coord = coordinator.read().await;
+        let group = coord.pipeline_groups.get(&group_id).expect("group missing");
+        let placement = group.placements.get("pipe-a").expect("pipe-a placement");
+        assert_eq!(
+            placement.worker_id,
+            WorkerId(w1_id.clone()),
+            "pipe-a should have failed over to w1 — the internal migrate must route \
+             over NATS (an HTTP POST to a nats:// address cannot succeed). \
+             failover_results={failover_results:?}"
+        );
+        assert_eq!(
+            placement.status,
+            PipelineDeploymentStatus::Running,
+            "pipe-a placement should be Running on w1 after failover"
+        );
+    }
+
+    // The pipeline is Running on w1's TenantManager (deployed over NATS)...
+    {
+        let mgr1 = tm1.read().await;
+        assert!(
+            mgr1.list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be Running on w1's TenantManager after failover"
+        );
+    }
+    // ...and torn down on w0's TenantManager (undeployed over NATS).
+    {
+        let mgr0 = tm0.read().await;
+        assert!(
+            !mgr0
+                .list_tenants()
+                .iter()
+                .any(|t| t.pipelines.values().any(|p| p.name == "pipe-a")),
+            "pipe-a should be torn down on w0 after failover"
+        );
+    }
+
+    h0.abort();
+    h1.abort();
+}


### PR DESCRIPTION
## What

C6 (#195) branched only the *manual* REST handlers onto NATS. The internal `Coordinator::migrate_pipeline` — the path behind **`handle_worker_failure`**, `drain_worker`, and `rebalance` — still POSTed over HTTP, so a **C5-triggered auto-failover** in a NATS deployment would try to reqwest a `nats://` worker address and fail. This closes the **C5→migration hazard** flagged in the C5/C6 work.

## How

`migrate_pipeline` now goes through the same `execute_migrate_plan_dispatch` the manual handler uses: NATS when `self.nats_client` is set, else HTTP `execute_migrate_plan_inner`. `distributed_checkpoint` is `None` on this internal path (no preloaded snapshot); the dead-source short-circuit is driven by `source_alive`, so failover from a genuinely dead source is preserved. The Result/error contract, placement bookkeeping (`commit_migrate_pipeline`), and the source `worker_metrics` purge are all preserved. Routing this one method covers all three failover callers.

## Test — REAL broker, fail-before/pass-after

`test_auto_failover_migrate_routes_over_nats`: deploy pipe-a to `nats://w0`, call the **real** `handle_worker_failure(w0)`, assert pipe-a migrated to `w1` + Running on w1's TenantManager (asserting on STATE, since `handle_worker_failure` swallows errors into its `Vec`).

**Verified fail-before (independently):** forcing the dispatch to HTTP → `builder error for url (nats://w1/api/v1/pipelines)` → pipe-a stranded on w0.

**No regression:** all existing **migration (12) + rebalance (3)** tests pass (HTTP semantics preserved); `nats_multi_worker_e2e` 8/8 + `nats_cluster_e2e` 6/6 + `raft_sim` 9/9; `make verify` green; feature clippy clean.

> `reconcile_placements` uses inline HTTP but is a stale-placement *redeploy*, not a migration — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)