### PR TITLE
fix(engine): preserve Sequence/Join routing across hot reload (audit HIGH)

### DIFF
--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -1621,8 +1621,6 @@ impl Engine {
             self.streams.remove(name);
         }
 
-        self.router.clear();
-
         for name in &report.streams_added {
             if let Some(stream) = new_engine.streams.remove(name) {
                 self.streams.insert(name.clone(), stream);
@@ -1635,35 +1633,17 @@ impl Engine {
             }
         }
 
-        let registrations: Vec<(String, String)> = self
-            .streams
-            .iter()
-            .flat_map(|(name, stream)| {
-                let mut pairs = Vec::new();
-                match &stream.source {
-                    RuntimeSource::EventType(et) => {
-                        pairs.push((et.clone(), name.clone()));
-                    }
-                    RuntimeSource::Stream(s) => {
-                        pairs.push((s.clone(), name.clone()));
-                    }
-                    RuntimeSource::Merge(sources) => {
-                        for ms in sources {
-                            pairs.push((ms.event_type.clone(), name.clone()));
-                        }
-                    }
-                    RuntimeSource::Join(_) => {}
-                    RuntimeSource::Timer(config) => {
-                        pairs.push((config.timer_event_type.clone(), name.clone()));
-                    }
-                }
-                pairs
-            })
-            .collect();
-
-        for (event_type, stream_name) in registrations {
-            self.router.add_route(&event_type, &stream_name);
-        }
+        // Adopt the freshly-compiled router wholesale instead of rebuilding it
+        // from each stream's `RuntimeSource`. That rebuild was lossy: the match
+        // below registered only ONE event type for a multi-event Sequence (its
+        // `RuntimeSource::EventType` first type) and NONE for a `Join`
+        // (`Join(_) => {}`), so after any hot reload — interactive edit, tenant
+        // update — Sequence and Join streams silently stopped receiving their
+        // other inputs and never matched again. `new_engine` fully compiled
+        // `program` (via `load`), so its router already holds the correct
+        // (every event type → stream) routes for exactly the reloaded set,
+        // built by the same pattern/join analysis as the initial compile.
+        self.router = std::mem::take(&mut new_engine.router);
 
         self.functions = new_engine.functions;
         self.patterns = new_engine.patterns;

--- a/crates/varpulis-runtime/tests/hot_reload_routing_tests.rs
+++ b/crates/varpulis-runtime/tests/hot_reload_routing_tests.rs
@@ -1,0 +1,70 @@
+//! Regression test for the hot-reload routing bug (audit HIGH).
+//!
+//! `Engine::reload` used to rebuild the router from each stream's
+//! `RuntimeSource`, which only exposes ONE event type for a multi-event
+//! Sequence and NONE for a Join. So after any hot reload — an interactive edit
+//! or a tenant update — Sequence and Join streams silently stopped receiving
+//! their other inputs and never matched again. The fix adopts the freshly
+//! compiled router (which registers every event type per stream).
+
+use tokio::sync::mpsc;
+use varpulis_parser::parse;
+use varpulis_runtime::engine::Engine;
+use varpulis_runtime::event::Event;
+
+/// A sequence stream that matches TWO event types (Order then Payment). Before
+/// the fix, reload kept only the `Order` route and dropped `Payment`.
+const SEQ_VPL: &str = "\
+event Order:
+    id: str
+event Payment:
+    order_id: str
+stream OrderPaymentMatch = Order as order
+    -> Payment where order_id == order.id as payment
+    .within(5m)
+    .emit(matched_order: order.id)
+";
+
+fn order(id: &str) -> Event {
+    Event::new("Order").with_field("id", id)
+}
+fn payment(order_id: &str) -> Event {
+    Event::new("Payment").with_field("order_id", order_id)
+}
+
+/// The sequence matches Order→Payment before reload, and must STILL match after
+/// reloading the same program. Fail-before: reverting `reload`'s router rebuild
+/// drops the `Payment` route, so the post-reload sequence never completes and
+/// the second assertion fails.
+#[tokio::test]
+async fn sequence_stream_still_matches_after_hot_reload() {
+    let program = parse(SEQ_VPL).expect("parse SEQ_VPL");
+    let (tx, mut rx) = mpsc::channel::<Event>(64);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+
+    // Baseline: Order then Payment completes the sequence and emits.
+    engine.process(order("o1")).await.expect("process order o1");
+    engine
+        .process(payment("o1"))
+        .await
+        .expect("process payment o1");
+    assert!(
+        rx.try_recv().is_ok(),
+        "sequence should match BEFORE reload (sanity check on the test itself)"
+    );
+
+    // Hot reload the identical program.
+    engine.reload(&program).expect("reload");
+
+    // The sequence must still match — the `Payment` route has to survive reload.
+    engine.process(order("o2")).await.expect("process order o2");
+    engine
+        .process(payment("o2"))
+        .await
+        .expect("process payment o2");
+    assert!(
+        rx.try_recv().is_ok(),
+        "sequence must STILL match after hot reload — the Payment route must survive"
+    );
+}


### PR DESCRIPTION
## What

**Audit HIGH — hot reload silently breaks Sequence and Join streams.** `Engine::reload` rebuilt the router from each stream's `RuntimeSource`, which is lossy:
- a multi-event **Sequence** exposes only its *first* event type as `RuntimeSource::EventType`, and
- a **Join** exposes none (`Join(_) => {}`).

So after **any** hot reload — an interactive edit or a tenant update — Sequence and Join streams silently stopped receiving their other inputs and never matched again, while everything reported healthy.

## How

Adopt the freshly-compiled router wholesale. `reload` already builds `new_engine` by fully compiling the new program (`load`), so its router already holds the correct *(every event type → stream)* routes for exactly the reloaded set — built by the same pattern/join analysis as the initial compile. Replace the `clear()` + rebuild-from-`RuntimeSource` with `self.router = std::mem::take(&mut new_engine.router)`.

## Test — fail-before / pass-after (in-memory, non-ignored)

`sequence_stream_still_matches_after_hot_reload`: load an `Order → Payment` sequence, confirm it matches, **reload** the same program, assert it *still* matches.

**Verified fail-before:** restoring the `RuntimeSource` rebuild drops the `Payment` route → the post-reload sequence never completes → the assertion panics.

**No regression:** 60 existing reload-caller tests (`engine_extended_tests`) + 580 runtime lib tests pass; `make verify` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)