### PR TITLE
fix(cluster): replicate heartbeat_seq over the NATS path (C5 multi-coord follow-up)

### DIFF
--- a/crates/varpulis-cluster/src/api.rs
+++ b/crates/varpulis-cluster/src/api.rs
@@ -697,6 +697,65 @@ async fn handle_register_worker(
     reply_json_status(&resp, StatusCode::CREATED)
 }
 
+/// Replicate a worker's latest heartbeat metrics — including the monotonic
+/// `heartbeat_seq` liveness counter that [`Coordinator::heartbeat`] just
+/// advanced — through Raft, so that every coordinator (not only the one that
+/// received the heartbeat) can tell a live worker from a dead one via
+/// `Coordinator::sync_from_raft`.
+///
+/// Mirrors the leader-write-or-forward pattern used across this module: the
+/// leader writes straight to its Raft log; a follower forwards the command to
+/// the leader's `/raft/write` endpoint. Shared verbatim by both heartbeat
+/// ingress paths — the HTTP handler ([`handle_heartbeat`]) and the NATS handler
+/// (`nats_coordinator::handle_heartbeat_message`) — so worker liveness reaches
+/// Raft identically regardless of transport (audit C5). Consumes the write
+/// guard so the follower branch can release the coordinator lock before its
+/// HTTP round-trip. Replication failures are logged, not fatal.
+#[cfg(feature = "raft")]
+pub(crate) async fn replicate_heartbeat_to_raft(
+    coord: tokio::sync::RwLockWriteGuard<'_, Coordinator>,
+    worker_id: &str,
+    body: &HeartbeatRequest,
+) {
+    // Read back the monotonic heartbeat counter that `heartbeat()` just
+    // advanced for this worker; replicating it is what lets other coordinators
+    // detect liveness (see `sync_from_raft`).
+    let heartbeat_seq = coord
+        .workers
+        .get(&WorkerId(worker_id.to_string()))
+        .map(|w| w.heartbeat_seq)
+        .unwrap_or(0);
+    let cmd = crate::raft::ClusterCommand::WorkerMetricsUpdated {
+        id: worker_id.to_string(),
+        events_processed: body.events_processed,
+        pipelines_running: body.pipelines_running,
+        pipeline_metrics: body.pipeline_metrics.clone(),
+        heartbeat_seq,
+    };
+    if coord.is_raft_leader() {
+        // Leader: write directly to the Raft log.
+        if let Some(ref handle) = coord.raft_handle {
+            if let Err(e) = handle.raft.client_write(cmd).await {
+                tracing::debug!("Failed to replicate heartbeat metrics to Raft: {e}");
+            }
+        }
+    } else if let Some(leader_addr) = coord.raft_leader_addr() {
+        // Follower: forward to the leader's /raft/write endpoint.
+        let client = coord.http_client.clone();
+        let admin_key = coord.raft_handle.as_ref().and_then(|h| h.admin_key.clone());
+        // Don't hold the lock during HTTP I/O.
+        drop(coord);
+        let url = format!("{}/raft/write", leader_addr);
+        let mut req = client.post(&url).json(&cmd);
+        if let Some(key) = admin_key {
+            req = req.header("x-api-key", key);
+        }
+        if let Err(e) = req.send().await {
+            tracing::debug!("Failed to forward heartbeat metrics to Raft leader: {e}");
+        }
+    }
+}
+
 async fn handle_heartbeat(
     State(state): State<AppState>,
     Path(worker_id): Path<String>,
@@ -705,58 +764,19 @@ async fn handle_heartbeat(
 ) -> Response {
     let coordinator = state.coordinator.clone();
     let mut coord = coordinator.write().await;
-    match coord.heartbeat(&WorkerId(worker_id.clone()), &body) {
-        Ok(()) => {
-            // Replicate heartbeat metrics through Raft so all coordinators
-            // (including the leader that serves /api/v1/cluster/workers) see
-            // up-to-date events_processed and pipelines_running.
-            #[cfg(feature = "raft")]
-            {
-                // Read back the monotonic heartbeat counter that `heartbeat()`
-                // just advanced for this worker; replicating it is what lets
-                // other coordinators detect liveness (see `sync_from_raft`).
-                let heartbeat_seq = coord
-                    .workers
-                    .get(&WorkerId(worker_id.clone()))
-                    .map(|w| w.heartbeat_seq)
-                    .unwrap_or(0);
-                let cmd = crate::raft::ClusterCommand::WorkerMetricsUpdated {
-                    id: worker_id,
-                    events_processed: body.events_processed,
-                    pipelines_running: body.pipelines_running,
-                    pipeline_metrics: body.pipeline_metrics.clone(),
-                    heartbeat_seq,
-                };
-                if coord.is_raft_leader() {
-                    // Leader: write directly to Raft log
-                    if let Some(ref handle) = coord.raft_handle {
-                        if let Err(e) = handle.raft.client_write(cmd).await {
-                            tracing::debug!("Failed to replicate heartbeat metrics to Raft: {e}");
-                        }
-                    }
-                } else if let Some(leader_addr) = coord.raft_leader_addr() {
-                    // Follower: forward to leader's /raft/write endpoint
-                    let client = coord.http_client.clone();
-                    let admin_key = coord.raft_handle.as_ref().and_then(|h| h.admin_key.clone());
-                    // Don't hold the lock during HTTP I/O
-                    drop(coord);
-                    let url = format!("{}/raft/write", leader_addr);
-                    let mut req = client.post(&url).json(&cmd);
-                    if let Some(key) = admin_key {
-                        req = req.header("x-api-key", key);
-                    }
-                    if let Err(e) = req.send().await {
-                        tracing::debug!("Failed to forward heartbeat metrics to Raft leader: {e}");
-                    }
-                }
-            }
-            reply_with_status(
-                Json(&HeartbeatResponse { acknowledged: true }),
-                StatusCode::OK,
-            )
-        }
-        Err(e) => error_response(StatusCode::NOT_FOUND, &e.to_string()),
+    if let Err(e) = coord.heartbeat(&WorkerId(worker_id.clone()), &body) {
+        return error_response(StatusCode::NOT_FOUND, &e.to_string());
     }
+    // Replicate the heartbeat metrics + monotonic liveness counter through Raft
+    // so all coordinators (including the leader that serves
+    // /api/v1/cluster/workers) see up-to-date events_processed,
+    // pipelines_running, and heartbeat_seq. No-op when `raft` is off.
+    #[cfg(feature = "raft")]
+    replicate_heartbeat_to_raft(coord, &worker_id, &body).await;
+    reply_with_status(
+        Json(&HeartbeatResponse { acknowledged: true }),
+        StatusCode::OK,
+    )
 }
 
 async fn handle_list_workers(

--- a/crates/varpulis-cluster/src/nats_coordinator.rs
+++ b/crates/varpulis-cluster/src/nats_coordinator.rs
@@ -136,16 +136,20 @@ async fn handle_heartbeat_message(subject: &str, payload: &[u8], coordinator: &S
     let mut coord = coordinator.write().await;
     if let Err(e) = coord.heartbeat(&wid, &hb) {
         warn!("Heartbeat error for {}: {}", worker_id, e);
+        // A bad heartbeat has nothing to replicate; under `raft` we must skip the
+        // replication below (this early return is compiled out when `raft` is off,
+        // where there is no trailing code and the return would be redundant).
+        #[cfg(feature = "raft")]
+        return;
     }
-    // NOTE (C5 / C6 follow-up): unlike the HTTP heartbeat handler
-    // (`api.rs` `handle_heartbeat`), this NATS path advances the worker's
-    // local `heartbeat_seq` via `heartbeat()` but does NOT replicate a
-    // `WorkerMetricsUpdated` through Raft — the NATS handler doesn't replicate
-    // metrics at all today. That is fine for a single coordinator (its own
-    // `heartbeat()` keeps `last_heartbeat` fresh) but means that in a
-    // multi-coordinator NATS deployment a worker homed on a *non-leader* would
-    // not have its liveness seen by the leader's `sync_from_raft`. Wiring
-    // leader-write-or-forward replication here belongs with the NATS outbound
-    // work (audit C6); until then, prefer HTTP heartbeats for multi-coordinator
-    // liveness.
+    // Replicate the heartbeat metrics + monotonic `heartbeat_seq` through Raft,
+    // exactly like the HTTP heartbeat handler (`api::handle_heartbeat`), via the
+    // shared leader-write-or-forward helper. Without this, the NATS path would
+    // advance only the *local* `heartbeat_seq` (via `heartbeat()` above) and
+    // never replicate it — so in a multi-coordinator NATS deployment a worker
+    // homed on a *non-leader* would have its liveness invisible to the leader's
+    // `sync_from_raft`, which could then false-mark it `Unhealthy` (audit C5).
+    // No-op when `raft` is off (single-coordinator liveness needs no replication).
+    #[cfg(feature = "raft")]
+    crate::api::replicate_heartbeat_to_raft(coord, worker_id, &hb).await;
 }

--- a/crates/varpulis-cluster/tests/nats_heartbeat_replication.rs
+++ b/crates/varpulis-cluster/tests/nats_heartbeat_replication.rs
@@ -1,0 +1,430 @@
+//! Regression test for audit critical **C5** on the NATS heartbeat path.
+//!
+//! The HTTP heartbeat handler replicates a worker's monotonic `heartbeat_seq`
+//! through Raft (`ClusterCommand::WorkerMetricsUpdated`) so that *every*
+//! coordinator — not just the one a worker is homed on — can tell a live worker
+//! from a dead one. Before the fix, the NATS heartbeat handler advanced only the
+//! receiving coordinator's *local* `heartbeat_seq` and never replicated it, so a
+//! NATS-homed worker on a non-leader coordinator would be invisible to the
+//! leader's `sync_from_raft` and could be false-marked `Unhealthy`.
+//!
+//! This test drives a heartbeat over the **real NATS broker** into the real
+//! `run_coordinator_nats_handler`, wired to a **real single-node in-memory Raft**
+//! (the same `SimRouter` harness pattern used by `raft_sim_tests.rs`) wrapped in
+//! a real `Coordinator`, then asserts the **replicated** `WorkerEntry.heartbeat_seq`
+//! in the Raft state machine advanced — i.e. the NATS heartbeat reached Raft.
+//! No mocking: real broker + real Raft.
+//!
+//! Fail-before / pass-after gate: deleting the replication call in
+//! `nats_coordinator::handle_heartbeat_message` makes the replicated
+//! `heartbeat_seq` stay frozen at 0, so the "advanced past 0" assertion times
+//! out and the test fails.
+//!
+//! Requires both features and a broker:
+//! `cargo test -p varpulis-cluster --features "raft,nats-transport" \
+//!     --test nats_heartbeat_replication`
+//! A `nats-server` must be listening on `nats://localhost:4222`; if it is not,
+//! the test prints `[skip]` and returns green.
+#![cfg(all(feature = "raft", feature = "nats-transport"))]
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use openraft::error::{InstallSnapshotError, RPCError, RaftError};
+use openraft::network::{RPCOption, RaftNetwork, RaftNetworkFactory};
+use openraft::raft::{
+    AppendEntriesRequest, AppendEntriesResponse, InstallSnapshotRequest, InstallSnapshotResponse,
+    VoteRequest, VoteResponse,
+};
+use tokio::sync::{mpsc, oneshot, RwLock};
+use uuid::Uuid;
+use varpulis_cluster::nats_coordinator::run_coordinator_nats_handler;
+use varpulis_cluster::nats_transport::{connect_nats, nats_publish, subject_heartbeat};
+use varpulis_cluster::raft::store::SharedCoordinatorState;
+use varpulis_cluster::raft::{
+    bootstrap_with_network, ClusterCommand, NodeId, RaftNode, TypeConfig, VarpulisRaft,
+};
+use varpulis_cluster::worker::{HeartbeatRequest, WorkerCapacity};
+use varpulis_cluster::{Coordinator, SharedCoordinator};
+
+const NATS_URL: &str = "nats://localhost:4222";
+
+// =========================================================================
+// Minimal in-process simulated Raft network (single-node subset of the
+// `SimRouter` harness in `raft_sim_tests.rs`). For a 1-node cluster no RPCs
+// are ever sent to peers, so the router just needs to exist; the node elects
+// itself and commits/applies writes locally through real openraft machinery.
+// =========================================================================
+
+enum RpcRequest {
+    Vote {
+        req: VoteRequest<NodeId>,
+        tx: oneshot::Sender<VoteResponse<NodeId>>,
+    },
+    AppendEntries {
+        req: AppendEntriesRequest<TypeConfig>,
+        tx: oneshot::Sender<AppendEntriesResponse<NodeId>>,
+    },
+    InstallSnapshot {
+        req: InstallSnapshotRequest<TypeConfig>,
+        tx: oneshot::Sender<InstallSnapshotResponse<NodeId>>,
+    },
+}
+
+struct SimRouter {
+    nodes: HashMap<NodeId, mpsc::Sender<RpcRequest>>,
+}
+
+impl SimRouter {
+    fn new() -> Self {
+        Self {
+            nodes: HashMap::new(),
+        }
+    }
+
+    fn add_node(&mut self, id: NodeId, tx: mpsc::Sender<RpcRequest>) {
+        self.nodes.insert(id, tx);
+    }
+
+    fn sender(&self, dst: NodeId) -> Option<mpsc::Sender<RpcRequest>> {
+        self.nodes.get(&dst).cloned()
+    }
+}
+
+#[derive(Clone)]
+struct SimNetworkFactory {
+    router: Arc<RwLock<SimRouter>>,
+}
+
+impl RaftNetworkFactory<TypeConfig> for SimNetworkFactory {
+    type Network = SimNetworkClient;
+
+    async fn new_client(&mut self, target: NodeId, _node: &RaftNode) -> Self::Network {
+        SimNetworkClient {
+            router: self.router.clone(),
+            target,
+        }
+    }
+}
+
+struct SimNetworkClient {
+    router: Arc<RwLock<SimRouter>>,
+    target: NodeId,
+}
+
+fn unreachable_err<E: std::error::Error>() -> RPCError<NodeId, RaftNode, E> {
+    RPCError::Unreachable(openraft::error::Unreachable::new(&std::io::Error::other(
+        "sim: node unreachable",
+    )))
+}
+
+impl RaftNetwork<TypeConfig> for SimNetworkClient {
+    async fn vote(
+        &mut self,
+        rpc: VoteRequest<NodeId>,
+        _option: RPCOption,
+    ) -> Result<VoteResponse<NodeId>, RPCError<NodeId, RaftNode, RaftError<NodeId>>> {
+        let sender = self
+            .router
+            .read()
+            .await
+            .sender(self.target)
+            .ok_or_else(unreachable_err)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .send(RpcRequest::Vote {
+                req: rpc,
+                tx: reply_tx,
+            })
+            .await
+            .map_err(|_| unreachable_err())?;
+        reply_rx.await.map_err(|_| unreachable_err())
+    }
+
+    async fn append_entries(
+        &mut self,
+        rpc: AppendEntriesRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<AppendEntriesResponse<NodeId>, RPCError<NodeId, RaftNode, RaftError<NodeId>>> {
+        let sender = self
+            .router
+            .read()
+            .await
+            .sender(self.target)
+            .ok_or_else(unreachable_err)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .send(RpcRequest::AppendEntries {
+                req: rpc,
+                tx: reply_tx,
+            })
+            .await
+            .map_err(|_| unreachable_err())?;
+        reply_rx.await.map_err(|_| unreachable_err())
+    }
+
+    async fn install_snapshot(
+        &mut self,
+        rpc: InstallSnapshotRequest<TypeConfig>,
+        _option: RPCOption,
+    ) -> Result<
+        InstallSnapshotResponse<NodeId>,
+        RPCError<NodeId, RaftNode, RaftError<NodeId, InstallSnapshotError>>,
+    > {
+        let sender = self
+            .router
+            .read()
+            .await
+            .sender(self.target)
+            .ok_or_else(unreachable_err)?;
+        let (reply_tx, reply_rx) = oneshot::channel();
+        sender
+            .send(RpcRequest::InstallSnapshot {
+                req: rpc,
+                tx: reply_tx,
+            })
+            .await
+            .map_err(|_| unreachable_err())?;
+        reply_rx.await.map_err(|_| unreachable_err())
+    }
+}
+
+async fn run_node_rpc_handler(raft: Arc<VarpulisRaft>, mut rx: mpsc::Receiver<RpcRequest>) {
+    while let Some(rpc) = rx.recv().await {
+        match rpc {
+            RpcRequest::Vote { req, tx } => {
+                let resp = raft.vote(req).await.expect("sim: raft.vote() error");
+                let _ = tx.send(resp);
+            }
+            RpcRequest::AppendEntries { req, tx } => {
+                let resp = raft
+                    .append_entries(req)
+                    .await
+                    .expect("sim: raft.append_entries() error");
+                let _ = tx.send(resp);
+            }
+            RpcRequest::InstallSnapshot { req, tx } => {
+                let resp = raft
+                    .install_snapshot(req)
+                    .await
+                    .expect("sim: raft.install_snapshot() error");
+                let _ = tx.send(resp);
+            }
+        }
+    }
+}
+
+/// Bootstrap a real single-node in-memory Raft and wait until it has elected
+/// itself leader (so `client_write` commits and applies locally). Returns the
+/// raft handle and its shared (replicated) coordinator state.
+async fn single_node_raft() -> (Arc<VarpulisRaft>, SharedCoordinatorState) {
+    let router = Arc::new(RwLock::new(SimRouter::new()));
+    let config = Arc::new(openraft::Config {
+        heartbeat_interval: 50,
+        election_timeout_min: 150,
+        election_timeout_max: 300,
+        ..Default::default()
+    });
+
+    let (inbox_tx, inbox_rx) = mpsc::channel(1024);
+    router.write().await.add_node(1, inbox_tx);
+
+    let net = SimNetworkFactory {
+        router: router.clone(),
+    };
+    let result = bootstrap_with_network(1, config, net)
+        .await
+        .expect("bootstrap failed");
+
+    tokio::spawn(run_node_rpc_handler(result.raft.clone(), inbox_rx));
+
+    let members: BTreeMap<NodeId, RaftNode> = BTreeMap::from([(
+        1,
+        RaftNode {
+            addr: "sim://1".to_string(),
+        },
+    )]);
+    result.raft.initialize(members).await.expect("initialize");
+
+    // Wait until node 1 is the elected leader.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+    loop {
+        let leader = result.raft.metrics().borrow().current_leader;
+        if leader == Some(1) {
+            break;
+        }
+        assert!(
+            tokio::time::Instant::now() < deadline,
+            "single-node Raft did not elect itself leader"
+        );
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    (result.raft, result.shared_state)
+}
+
+/// The replicated (Raft state-machine) `heartbeat_seq` for a worker, if present.
+fn replicated_seq(state: &SharedCoordinatorState, worker_id: &str) -> Option<u64> {
+    state
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .workers
+        .get(worker_id)
+        .map(|w| w.heartbeat_seq)
+}
+
+/// The replicated `events_processed` for a worker, if present.
+fn replicated_events(state: &SharedCoordinatorState, worker_id: &str) -> Option<u64> {
+    state
+        .read()
+        .unwrap_or_else(|e| e.into_inner())
+        .workers
+        .get(worker_id)
+        .map(|w| w.events_processed)
+}
+
+/// Poll the replicated state until the worker's `heartbeat_seq` reaches `min`,
+/// or the timeout elapses. Returns the observed seq on success, `None` on
+/// timeout.
+async fn wait_for_replicated_seq(
+    state: &SharedCoordinatorState,
+    worker_id: &str,
+    min: u64,
+    timeout: Duration,
+) -> Option<u64> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        if let Some(seq) = replicated_seq(state, worker_id) {
+            if seq >= min {
+                return Some(seq);
+            }
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return None;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}
+
+// =========================================================================
+// The gate
+// =========================================================================
+
+#[tokio::test]
+async fn nats_heartbeat_replicates_seq_through_raft() {
+    // Broker-skip-graceful: no broker ⇒ skip green (matches `connect_nats`).
+    let client = match connect_nats(NATS_URL).await {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("[skip] NATS broker unavailable at {NATS_URL}: {e}");
+            return;
+        }
+    };
+
+    // 1. Real single-node in-memory Raft (elected leader).
+    let (raft, shared_state) = single_node_raft().await;
+
+    // 2. Register a worker THROUGH Raft so a replicated WorkerEntry (seq = 0)
+    //    exists. Unique id so parallel runs don't collide on the shared broker.
+    let worker_id = format!("nats-hb-{}", Uuid::new_v4().simple());
+    raft.client_write(ClusterCommand::RegisterWorker {
+        id: worker_id.clone(),
+        address: "localhost:9100".to_string(),
+        api_key: "hb-key".to_string(),
+        capacity: WorkerCapacity {
+            cpu_cores: 4,
+            pipelines_running: 0,
+            max_pipelines: 100,
+        },
+    })
+    .await
+    .expect("register worker via Raft");
+
+    // Baseline: the replicated liveness counter starts at 0.
+    assert_eq!(
+        replicated_seq(&shared_state, &worker_id),
+        Some(0),
+        "freshly-registered worker should have replicated heartbeat_seq = 0"
+    );
+
+    // 3. Wrap the SAME Raft node + shared state in a real Coordinator and pull
+    //    the just-registered worker into its local map so the NATS handler's
+    //    `heartbeat()` finds it.
+    let mut coord =
+        Coordinator::with_raft(raft.clone(), shared_state.clone(), BTreeMap::new(), None);
+    coord.sync_from_raft();
+    let coordinator: SharedCoordinator = Arc::new(RwLock::new(coord));
+
+    // 4. Run the REAL coordinator-side NATS handler against the live broker.
+    let handler = tokio::spawn(run_coordinator_nats_handler(
+        client.clone(),
+        coordinator.clone(),
+    ));
+    // Let the subscriptions establish.
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // 5. First heartbeat over NATS on the subject the handler subscribes to.
+    let hb1 = HeartbeatRequest {
+        events_processed: 111,
+        pipelines_running: 1,
+        pipeline_metrics: vec![],
+    };
+    nats_publish(&client, &subject_heartbeat(&worker_id), &hb1)
+        .await
+        .expect("publish heartbeat 1");
+    client.flush().await.expect("flush");
+
+    // ASSERT: the replicated heartbeat_seq advanced past 0 — the NATS heartbeat
+    // reached Raft. (Fail-before: without the replication call this times out.)
+    let seq1 = wait_for_replicated_seq(&shared_state, &worker_id, 1, Duration::from_secs(5))
+        .await
+        .unwrap_or_else(|| {
+            panic!(
+                "C5(NATS): the first NATS heartbeat did NOT advance the replicated \
+                 heartbeat_seq past 0 — it never reached Raft (observed {:?})",
+                replicated_seq(&shared_state, &worker_id)
+            )
+        });
+    assert!(
+        seq1 >= 1,
+        "replicated heartbeat_seq should advance to >= 1, got {seq1}"
+    );
+    // The metrics rode along on the same replicated command.
+    assert_eq!(
+        replicated_events(&shared_state, &worker_id),
+        Some(111),
+        "events_processed should have been replicated alongside heartbeat_seq"
+    );
+
+    // 6. Second heartbeat: the replicated seq must advance again (monotonic).
+    let hb2 = HeartbeatRequest {
+        events_processed: 222,
+        pipelines_running: 2,
+        pipeline_metrics: vec![],
+    };
+    nats_publish(&client, &subject_heartbeat(&worker_id), &hb2)
+        .await
+        .expect("publish heartbeat 2");
+    client.flush().await.expect("flush");
+
+    let seq2 = wait_for_replicated_seq(&shared_state, &worker_id, seq1 + 1, Duration::from_secs(5))
+        .await
+        .unwrap_or_else(|| {
+            panic!(
+                "C5(NATS): the second NATS heartbeat did NOT advance the replicated \
+                 heartbeat_seq again (still {seq1})"
+            )
+        });
+    assert!(
+        seq2 > seq1,
+        "the second NATS heartbeat must advance the replicated seq: {seq1} -> {seq2}"
+    );
+    assert_eq!(
+        replicated_events(&shared_state, &worker_id),
+        Some(222),
+        "second heartbeat's events_processed should have been replicated"
+    );
+
+    handler.abort();
+}


### PR DESCRIPTION
## What

C5 (#191) made dead-worker detection work via a monotonic `heartbeat_seq` replicated through Raft — but **only the HTTP heartbeat handler replicated it**. The NATS heartbeat path advanced only the worker's *local* seq (via `heartbeat()`) and never wrote `WorkerMetricsUpdated` to Raft. So in a **multi-coordinator NATS** deployment, a worker homed on a *non-leader* had its liveness invisible to the leader's `sync_from_raft`, which could then **false-mark a live worker `Unhealthy`**. (This was the documented known-limitation in #191.)

## How

- Factor the HTTP handler's inline leader-write-or-forward into a shared `pub(crate) api::replicate_heartbeat_to_raft(guard, worker_id, body)`: reads back the seq `heartbeat()` just advanced, builds `WorkerMetricsUpdated`, then `client_write`s (leader) or forwards to the leader's `/raft/write` (follower, **dropping the coordinator lock before the HTTP round-trip**). Failures logged, not fatal.
- `nats_coordinator::handle_heartbeat_message` now calls that helper after `coord.heartbeat(...)`, so worker liveness reaches Raft **identically on both transports**. `heartbeat()` and `sync_from_raft` untouched; no-op when `raft` is off; compiles in all four feature combos.

## Test — REAL broker + in-memory Raft, fail-before/pass-after

`nats_heartbeat_replicates_seq_through_raft` runs the **real** `run_coordinator_nats_handler` against the live broker, publishes to `varpulis.cluster.heartbeat.{id}`, and asserts the **replicated** `WorkerEntry.heartbeat_seq` in the Raft state machine advances (0 → ≥1 → again). Driven through the real subject — not a direct-call fallback.

**Verified fail-before (independently):** deleting the replication call leaves the replicated seq at 0 (`never reached Raft, observed Some(0)`).

`raft_sim` **9/9** (incl. the C5 dead-worker test) + `nats_cluster_e2e` **6/6** + `nats_multi_worker_e2e` **7/7**; fmt + clippy (`raft`, `nats-transport`, and the combo) clean; `make verify` green.

## Cluster NATS completeness
With #195 (outbound), #196 (auto-failover migrate), and this PR, the NATS cluster transport is now on par with HTTP for the deploy/teardown/inject/migrate command paths **and** cross-coordinator liveness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)