### PR TITLE
fix(engine): evict empty partition windows on watermark advance (audit HIGH, OOM)

### DIFF
--- a/crates/varpulis-runtime/src/window.rs
+++ b/crates/varpulis-runtime/src/window.rs
@@ -167,6 +167,12 @@ pub struct SlidingWindow {
 }
 
 impl SlidingWindow {
+    /// Whether this window currently holds no events — used to evict idle
+    /// partition entries in [`PartitionedSlidingWindow`].
+    pub fn is_empty(&self) -> bool {
+        self.events.is_empty()
+    }
+
     pub const fn new(window_size: Duration, slide_interval: Duration) -> Self {
         Self {
             window_size,
@@ -922,6 +928,12 @@ pub struct PartitionedTumblingWindow {
 }
 
 impl PartitionedTumblingWindow {
+    /// Number of live partition keys currently held. Bounded by eviction of
+    /// empty windows on watermark advance (see `advance_watermark`).
+    pub fn partition_count(&self) -> usize {
+        self.windows.len()
+    }
+
     pub fn new(partition_key: String, duration: Duration) -> Self {
         Self {
             partition_key,
@@ -1029,6 +1041,12 @@ impl PartitionedTumblingWindow {
                 results.push((key.clone(), events));
             }
         }
+        // Evict partition keys whose window is now empty (fired past the
+        // watermark, or never filled) so a high-cardinality `partition_by`
+        // cannot grow this map without bound. A later event for the key simply
+        // re-creates its window — no data is lost. Mirrors the eviction the
+        // partitioned session window already performs.
+        self.windows.retain(|_, window| !window.is_empty());
         results
     }
 }
@@ -1043,6 +1061,12 @@ pub struct PartitionedSlidingWindow {
 }
 
 impl PartitionedSlidingWindow {
+    /// Number of live partition keys currently held. Bounded by eviction of
+    /// empty windows on watermark advance (see `advance_watermark`).
+    pub fn partition_count(&self) -> usize {
+        self.windows.len()
+    }
+
     pub fn new(partition_key: String, window_size: Duration, slide_interval: Duration) -> Self {
         Self {
             partition_key,
@@ -1144,6 +1168,12 @@ impl PartitionedSlidingWindow {
                 results.push((key.clone(), events));
             }
         }
+        // Evict partition keys whose window is now empty (fired past the
+        // watermark, or never filled) so a high-cardinality `partition_by`
+        // cannot grow this map without bound. A later event for the key simply
+        // re-creates its window — no data is lost. Mirrors the eviction the
+        // partitioned session window already performs.
+        self.windows.retain(|_, window| !window.is_empty());
         results
     }
 }
@@ -1661,6 +1691,12 @@ pub struct BinnedSlidingWindow {
 }
 
 impl BinnedSlidingWindow {
+    /// Whether this window currently holds no bins (hence no events) — used to
+    /// evict idle partition entries on watermark advance.
+    pub fn is_empty(&self) -> bool {
+        self.bins.is_empty()
+    }
+
     /// Create a new binned sliding window.
     ///
     /// `tracked_fields` lists field names for which per-bin aggregates are
@@ -2104,6 +2140,12 @@ impl PartitionedBinnedSlidingWindow {
                 results.push((key.clone(), events));
             }
         }
+        // Evict partition keys whose window is now empty (fired past the
+        // watermark, or never filled) so a high-cardinality `partition_by`
+        // cannot grow this map without bound. A later event for the key simply
+        // re-creates its window — no data is lost. Mirrors the eviction the
+        // partitioned session window already performs.
+        self.windows.retain(|_, window| !window.is_empty());
         results
     }
 

--- a/crates/varpulis-runtime/tests/window_coverage_tests.rs
+++ b/crates/varpulis-runtime/tests/window_coverage_tests.rs
@@ -981,3 +981,61 @@ fn count_window_single_event_window() {
     assert!(r.is_some());
     assert_eq!(r.unwrap().len(), 1);
 }
+
+// ============================================================================
+// Idle-partition eviction (unbounded-growth guard)
+// ============================================================================
+
+/// A high-cardinality `partition_by` (user id / IP / session) must not grow the
+/// per-partition window map without bound: once a partition's window has fired
+/// past the watermark and is empty, the entry is evicted. Fail-before: without
+/// the `retain` in `advance_watermark`, `partition_count()` stays at 100.
+#[test]
+fn partitioned_tumbling_evicts_empty_partitions_on_watermark() {
+    let base = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let mut w = PartitionedTumblingWindow::new("key".to_string(), Duration::seconds(5));
+
+    for i in 0..100 {
+        w.add_shared(shared(make_event("E", 0, vec![("key", Value::Int(i))])));
+    }
+    assert_eq!(
+        w.partition_count(),
+        100,
+        "100 distinct keys → 100 live partitions"
+    );
+
+    // Advance far past every 5s window — they all fire and empty.
+    w.advance_watermark(base + Duration::seconds(100));
+
+    assert_eq!(
+        w.partition_count(),
+        0,
+        "empty (fired) partition windows must be evicted on watermark advance"
+    );
+}
+
+/// Same guard for the partitioned sliding window: once every event has slid out
+/// of a partition's window it must be evicted, not retained forever.
+#[test]
+fn partitioned_sliding_evicts_empty_partitions_on_watermark() {
+    let base = chrono::DateTime::from_timestamp(1_700_000_000, 0).unwrap();
+    let mut w = PartitionedSlidingWindow::new(
+        "key".to_string(),
+        Duration::seconds(5),
+        Duration::seconds(1),
+    );
+
+    for i in 0..100 {
+        w.add_shared(shared(make_event("E", 0, vec![("key", Value::Int(i))])));
+    }
+    assert_eq!(w.partition_count(), 100);
+
+    // Advance far past window_size after the last event so every window empties.
+    w.advance_watermark(base + Duration::seconds(100));
+
+    assert_eq!(
+        w.partition_count(),
+        0,
+        "fully-slid-out partition windows must be evicted on watermark advance"
+    );
+}


### PR DESCRIPTION
## What

**Audit HIGH — unbounded growth → OOM.** `PartitionedTumblingWindow`, `PartitionedSlidingWindow`, and the binned sliding window advanced the watermark over their per-partition maps but **never evicted** partition entries whose window had emptied — only the partitioned *session* window did. Under a high-cardinality `partition_by` (user id / IP / session — one event per key), every key left a permanent map entry even after its window fired and drained: memory grows without bound → OOM on a long-running stream.

## How

After firing, each partitioned `advance_watermark` now `retain(|_, w| !w.is_empty())`, mirroring the eviction the partitioned session window already performs. An **empty** window holds no buffered events, so dropping it is safe — a later event for that key simply re-creates it, **no data lost**. Adds `SlidingWindow::is_empty`, `BinnedSlidingWindow::is_empty`, and a `partition_count()` accessor.

## Test — fail-before / pass-after (in-memory)

`partitioned_tumbling_evicts_empty_partitions_on_watermark` (+ sliding equivalent): add one event for each of **100 distinct keys** (`partition_count == 100`), advance the watermark far past every window so they all fire/slide-out, assert `partition_count() == 0`.

**Verified fail-before:** without the `retain`, the count stays **100**. 51 window tests + 580 runtime lib tests pass (no regression); `make verify` green.

## Follow-up
The per-source watermark idle timeout (`PerSourceWatermarkTracker` takes `min` over all sources → one quiet event type can freeze the whole-engine watermark; `last_event_time` written-but-never-read). That's a watermark-*correctness* change (choosing an idle-source timeout), not pure GC — left for its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)