### PR TITLE
fix(connector-kafka): stop silently dropping undecodable source records (audit HIGH)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8739,6 +8739,7 @@ dependencies = [
  "tracing",
  "varpulis-connector-api",
  "varpulis-core",
+ "varpulis-dead-letter",
 ]
 
 [[package]]

--- a/crates/varpulis-connector-api/src/managed.rs
+++ b/crates/varpulis-connector-api/src/managed.rs
@@ -31,6 +31,11 @@ pub struct ConnectorHealthReport {
     pub circuit_breaker_failures: u64,
     /// Total number of requests rejected by the circuit breaker.
     pub circuit_breaker_rejections: u64,
+    /// Total number of inbound records dropped because they could not be
+    /// decoded into an `Event` (malformed payload) or exceeded the payload
+    /// size limit. A non-zero value means poison records were observed (and
+    /// dead-lettered, when a DLQ is attached) rather than silently skipped.
+    pub decode_failures: u64,
 }
 
 impl Default for ConnectorHealthReport {
@@ -43,6 +48,7 @@ impl Default for ConnectorHealthReport {
             circuit_breaker_state: "closed".to_string(),
             circuit_breaker_failures: 0,
             circuit_breaker_rejections: 0,
+            decode_failures: 0,
         }
     }
 }

--- a/crates/varpulis-connector-kafka/Cargo.toml
+++ b/crates/varpulis-connector-kafka/Cargo.toml
@@ -11,6 +11,7 @@ description = "Kafka connector for Varpulis CEP engine"
 [dependencies]
 varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
 varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-dead-letter = { version = "0.10.0", path = "../varpulis-dead-letter" }
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-kafka/src/managed.rs
+++ b/crates/varpulis-connector-kafka/src/managed.rs
@@ -15,8 +15,11 @@ use tracing::{error, info};
 use varpulis_connector_api::circuit_breaker::{CircuitBreaker, CircuitBreakerConfig};
 use varpulis_connector_api::decode::EventDecoder;
 use varpulis_connector_api::sink::{Sink, SinkError};
-use varpulis_connector_api::{ConnectorError, EngineOffsetRegistry, ManagedConnector};
+use varpulis_connector_api::{
+    ConnectorError, ConnectorHealthReport, EngineOffsetRegistry, ManagedConnector,
+};
 use varpulis_core::Event;
+use varpulis_dead_letter::DeadLetterQueue;
 
 use crate::KafkaConfig;
 
@@ -145,6 +148,19 @@ pub struct ManagedKafkaConnector {
     /// so the checkpoint barrier can drain in-flight events and snapshot a
     /// coherent offset set. `None` until the driver wires it at startup.
     source_paused: Option<Arc<AtomicBool>>,
+    /// Count of source records that could not be turned into an `Event` — a
+    /// malformed payload that failed to decode, or an oversized record rejected
+    /// before decode. Shared with the spawned consume task, which increments it,
+    /// and read back via [`decode_failures`](Self::decode_failures) and the
+    /// connector health report. Audit HIGH: these used to be dropped silently
+    /// (a bare `debug!`) while the offset advanced past them; the counter makes
+    /// every drop observable.
+    decode_failures: Arc<AtomicU64>,
+    /// Optional dead-letter sink for raw, undecodable source payloads. When set
+    /// (via [`with_dead_letter_queue`](Self::with_dead_letter_queue)) the
+    /// original bytes of every dropped record are preserved here for inspection
+    /// or replay instead of being lost. `None` = count + warn only.
+    dead_letter: Option<Arc<DeadLetterQueue>>,
 }
 
 impl std::fmt::Debug for ManagedKafkaConnector {
@@ -168,7 +184,26 @@ impl ManagedKafkaConnector {
             engine_offsets: None,
             txn_state: None,
             source_paused: None,
+            decode_failures: Arc::new(AtomicU64::new(0)),
+            dead_letter: None,
         }
+    }
+
+    /// Attach a dead-letter queue for raw source payloads that fail to decode
+    /// (malformed) or exceed the size limit. Without one, such records are still
+    /// counted and logged; with one, their original bytes are additionally
+    /// preserved for inspection or replay so nothing is silently dropped.
+    pub fn with_dead_letter_queue(mut self, dlq: Arc<DeadLetterQueue>) -> Self {
+        self.dead_letter = Some(dlq);
+        self
+    }
+
+    /// Number of source records dropped because they could not be decoded into
+    /// an `Event` or exceeded the payload size limit. A non-zero value means
+    /// poison records were observed (and dead-lettered, if a DLQ is attached),
+    /// never silently discarded.
+    pub fn decode_failures(&self) -> u64 {
+        self.decode_failures.load(Ordering::Relaxed)
     }
 
     fn ensure_producer(&mut self) -> Result<FutureProducer, ConnectorError> {
@@ -238,6 +273,13 @@ impl ManagedConnector for ManagedKafkaConnector {
 
     fn connector_type(&self) -> &str {
         "kafka"
+    }
+
+    fn health(&self) -> ConnectorHealthReport {
+        ConnectorHealthReport {
+            decode_failures: self.decode_failures.load(Ordering::Relaxed),
+            ..Default::default()
+        }
     }
 
     #[tracing::instrument(level = "debug", skip(self, tx, params))]
@@ -326,6 +368,8 @@ impl ManagedConnector for ManagedKafkaConnector {
         let topic_owned = topic.to_string();
         let engine_offsets = self.engine_offsets.clone();
         let source_paused = self.source_paused.clone();
+        let decode_failures = self.decode_failures.clone();
+        let dead_letter = self.dead_letter.clone();
 
         tokio::spawn(async move {
             use futures_util::StreamExt;
@@ -442,11 +486,30 @@ impl ManagedConnector for ManagedKafkaConnector {
                                     if payload.len()
                                         > varpulis_connector_api::limits::MAX_EVENT_PAYLOAD_BYTES
                                     {
+                                        // Oversized record: reject before decode, but do NOT
+                                        // drop it silently. Count it, warn with its
+                                        // coordinates, and dead-letter the raw bytes when a
+                                        // DLQ is attached so it stays recoverable.
+                                        decode_failures.fetch_add(1, Ordering::Relaxed);
                                         tracing::warn!(
-                                            "Managed Kafka {}: payload too large ({} bytes), skipped",
+                                            topic = %topic_owned,
+                                            partition,
+                                            offset = msg_offset,
+                                            payload_len = payload.len(),
+                                            limit = varpulis_connector_api::limits::MAX_EVENT_PAYLOAD_BYTES,
+                                            "Managed Kafka {}: payload too large, dead-lettered and skipped",
                                             name,
-                                            payload.len()
                                         );
+                                        if let Some(ref dlq) = dead_letter {
+                                            dlq.write_raw(
+                                                &name,
+                                                "kafka source: payload exceeds size limit",
+                                                &format!(
+                                                    "topic={topic_owned} partition={partition} offset={msg_offset}"
+                                                ),
+                                                payload,
+                                            );
+                                        }
                                     } else {
                                         match decoder.decode("KafkaEvent", payload) {
                                             Ok(event) => {
@@ -454,11 +517,35 @@ impl ManagedConnector for ManagedKafkaConnector {
                                                 pushed = true;
                                             }
                                             Err(e) => {
-                                                tracing::debug!(
-                                                    "Managed Kafka {}: JSON decode failed, skipped: {}",
+                                                // Audit HIGH: a decode failure used to be a
+                                                // bare `debug!` while the offset advanced past
+                                                // the record (via later records' high-water
+                                                // mark) — a silent, unrecoverable gap that
+                                                // breaks the "never silently dropped" promise.
+                                                // Now: count it, `warn!` with the exact
+                                                // topic/partition/offset, and dead-letter the
+                                                // raw bytes when a DLQ is attached.
+                                                decode_failures.fetch_add(1, Ordering::Relaxed);
+                                                tracing::warn!(
+                                                    topic = %topic_owned,
+                                                    partition,
+                                                    offset = msg_offset,
+                                                    error = %e,
+                                                    "Managed Kafka {}: decode failed, dead-lettered and skipped",
                                                     name,
-                                                    e
                                                 );
+                                                if let Some(ref dlq) = dead_letter {
+                                                    dlq.write_raw(
+                                                        &name,
+                                                        &format!(
+                                                            "kafka source: decode failed: {e}"
+                                                        ),
+                                                        &format!(
+                                                            "topic={topic_owned} partition={partition} offset={msg_offset}"
+                                                        ),
+                                                        payload,
+                                                    );
+                                                }
                                             }
                                         }
                                     }

--- a/crates/varpulis-dead-letter/src/lib.rs
+++ b/crates/varpulis-dead-letter/src/lib.rs
@@ -26,6 +26,12 @@ impl Default for DlqConfig {
     }
 }
 
+/// Raw source payloads are truncated to this many bytes before being written
+/// to the DLQ, bounding the on-disk line size for pathological (e.g. oversized)
+/// records. The full original length is always recorded separately in
+/// [`DlqRawEntry::payload_len`].
+const MAX_RAW_PAYLOAD_BYTES: usize = 65_536;
+
 /// A dead letter queue entry with error metadata.
 #[derive(serde::Serialize)]
 struct DlqEntry<'a> {
@@ -37,6 +43,32 @@ struct DlqEntry<'a> {
     error: &'a str,
     /// The event that failed to deliver.
     event: &'a Event,
+}
+
+/// A dead letter entry for a **raw** payload that could not be decoded into an
+/// [`Event`] — e.g. a malformed-JSON or oversized record rejected at a *source*
+/// before it ever became an `Event`. There is no `Event` to attach, so the
+/// original bytes (best-effort UTF-8, truncated) are preserved alongside the
+/// source coordinates so the record stays inspectable and replayable instead of
+/// being silently dropped with its offset advanced past it.
+#[derive(serde::Serialize)]
+struct DlqRawEntry<'a> {
+    /// ISO-8601 timestamp when the payload was dead-lettered.
+    timestamp: String,
+    /// Source connector name.
+    connector: &'a str,
+    /// Why the payload was rejected (decode error text or size-limit message).
+    error: &'a str,
+    /// Source coordinates, e.g. `"topic=t partition=0 offset=42"`.
+    source: &'a str,
+    /// Original payload rendered as best-effort UTF-8 and truncated to
+    /// [`MAX_RAW_PAYLOAD_BYTES`]. Malformed-JSON text round-trips exactly;
+    /// non-UTF-8 bytes are replaced with U+FFFD.
+    payload: String,
+    /// True byte length of the original payload, before truncation.
+    payload_len: usize,
+    /// Whether `payload` was truncated (`payload_len > MAX_RAW_PAYLOAD_BYTES`).
+    truncated: bool,
 }
 
 /// Owned version of a DLQ entry for reading entries back.
@@ -108,6 +140,39 @@ impl DeadLetterQueue {
             connector,
             error,
             event,
+        };
+
+        if let Ok(line) = serde_json::to_string(&entry) {
+            let mut file = self.file.lock().unwrap_or_else(|e| e.into_inner());
+            // Best-effort: log but don't propagate DLQ write errors.
+            if writeln!(file, "{line}").is_ok() {
+                self.events_total.fetch_add(1, Ordering::Relaxed);
+                self.current_lines.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        self.maybe_rotate();
+    }
+
+    /// Write a **raw**, undecodable source payload to the DLQ.
+    ///
+    /// Unlike [`write`](Self::write), this accepts bytes that never became an
+    /// [`Event`] — a source-side decode failure or an oversized record. The
+    /// bytes are preserved (best-effort UTF-8, truncated to a bounded size)
+    /// together with the source coordinates so the record can be inspected or
+    /// replayed. This is the Varpulis "never silently dropped" guarantee applied
+    /// to the ingest path: a poison record is captured here instead of vanishing
+    /// as the consumer offset advances past it.
+    pub fn write_raw(&self, connector: &str, error: &str, source: &str, payload: &[u8]) {
+        let capped = &payload[..payload.len().min(MAX_RAW_PAYLOAD_BYTES)];
+        let entry = DlqRawEntry {
+            timestamp: chrono::Utc::now().to_rfc3339(),
+            connector,
+            error,
+            source,
+            payload: String::from_utf8_lossy(capped).into_owned(),
+            payload_len: payload.len(),
+            truncated: payload.len() > MAX_RAW_PAYLOAD_BYTES,
         };
 
         if let Ok(line) = serde_json::to_string(&entry) {
@@ -286,6 +351,68 @@ mod tests {
         assert_eq!(entry["error"], "connection refused");
         assert!(entry["timestamp"].is_string());
         assert!(entry["event"].is_object());
+
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    #[test]
+    fn test_dlq_write_raw_preserves_bytes_and_metadata() {
+        let dir = std::env::temp_dir().join("varpulis_dlq_raw_test");
+        let _ = std::fs::remove_file(&dir);
+
+        let dlq = DeadLetterQueue::open(&dir).unwrap();
+        assert_eq!(dlq.count(), 0);
+
+        let malformed = b"{ this is not json";
+        dlq.write_raw(
+            "kafka-source",
+            "decode failed: expected value",
+            "topic=events partition=0 offset=42",
+            malformed,
+        );
+        assert_eq!(dlq.count(), 1);
+
+        // The raw entry is a valid JSON line carrying the original bytes and
+        // source coordinates — so the poison record is recoverable, not lost.
+        let content = std::fs::read_to_string(&dir).unwrap();
+        let entry: serde_json::Value =
+            serde_json::from_str(content.lines().next().unwrap()).unwrap();
+        assert_eq!(entry["connector"], "kafka-source");
+        assert_eq!(entry["source"], "topic=events partition=0 offset=42");
+        assert_eq!(entry["payload"], "{ this is not json");
+        assert_eq!(entry["payload_len"], malformed.len());
+        assert_eq!(entry["truncated"], false);
+        assert!(entry["timestamp"].is_string());
+
+        let _ = std::fs::remove_file(&dir);
+    }
+
+    #[test]
+    fn test_dlq_write_raw_truncates_oversized_payload() {
+        let dir = std::env::temp_dir().join("varpulis_dlq_raw_trunc_test");
+        let _ = std::fs::remove_file(&dir);
+
+        let dlq = DeadLetterQueue::open(&dir).unwrap();
+
+        let huge = vec![b'x'; MAX_RAW_PAYLOAD_BYTES + 4_096];
+        dlq.write_raw(
+            "kafka-source",
+            "payload too large",
+            "topic=t offset=1",
+            &huge,
+        );
+
+        let content = std::fs::read_to_string(&dir).unwrap();
+        let entry: serde_json::Value =
+            serde_json::from_str(content.lines().next().unwrap()).unwrap();
+        // Full length is recorded even though the stored bytes are capped.
+        assert_eq!(entry["payload_len"], huge.len());
+        assert_eq!(entry["truncated"], true);
+        assert_eq!(
+            entry["payload"].as_str().unwrap().len(),
+            MAX_RAW_PAYLOAD_BYTES,
+            "stored payload must be capped at MAX_RAW_PAYLOAD_BYTES"
+        );
 
         let _ = std::fs::remove_file(&dir);
     }


### PR DESCRIPTION
## What

**Audit HIGH — "never silently dropped" broken.** A Kafka source record that failed to decode (or exceeded the payload size cap) was dropped with only a `debug!`/`warn!` while the consumer advanced past it: a silent, unrecoverable gap.

## How

Both skip sites in the managed consumer loop now, on a decode failure / oversized payload: **increment a `decode_failures` counter**, `warn!` with the exact **topic/partition/offset**, and — when a DLQ is attached — **dead-letter the raw bytes**. The delicate exactly-once/checkpoint **offset machinery is untouched** — the consumer keeps making progress, but every drop is now observable + recoverable rather than silent.

- `varpulis-dead-letter`: new `write_raw()` preserving raw undecodable bytes (best-effort UTF-8, 64 KiB cap, true `payload_len`) + source coordinates.
- `ManagedKafkaConnector`: `with_dead_letter_queue(...)`, `decode_failures() -> u64`, surfaced on `ConnectorHealthReport.decode_failures`.

## Test — REAL Redpanda, fail-before/pass-after, deterministic

`malformed_source_record_is_counted_and_dead_lettered_not_silently_dropped`: 1-partition topic, produce **2 valid → 1 malformed → 2 valid**, drain, assert all 4 valid arrive, `decode_failures() == 1`, and the raw bytes + coordinates landed in the DLQ file.

**Verified fail-before (independently, live broker):** reverting to the silent skip leaves the counter at 0 (the valid-events assertion still passes → isolates the observability gap). Broker-skip-graceful. Existing kafka + dead-letter + connector-api tests pass; `make verify` green.

## Deferred follow-ups (flagged)
Auto-inject the source DLQ from pipeline config at the engine layer (currently opt-in via the builder; needs `set_dead_letter_queue` on the `ManagedConnector` trait). A null/empty payload (compacted-topic tombstone) is intentionally **not** treated as a decode failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)