### PR TITLE
fix(engine): bound TrendAggregate.accumulated to the WITHIN window (audit HIGH, OOM)

### DIFF
--- a/crates/varpulis-runtime/src/engine/compilation.rs
+++ b/crates/varpulis-runtime/src/engine/compilation.rs
@@ -1626,6 +1626,7 @@ impl Engine {
                 field_aggregates,
                 type_index_to_name,
                 accumulated: Vec::new(),
+                window_ms,
             }),
         );
 

--- a/crates/varpulis-runtime/src/engine/pipeline.rs
+++ b/crates/varpulis-runtime/src/engine/pipeline.rs
@@ -1059,9 +1059,38 @@ fn execute_op_common(
                     None
                 };
 
+            // Hard backstop against a pathological high-rate stream filling the
+            // window with more events than fit in memory. Well above any real
+            // WITHIN window's worth; only trips in abuse/runaway cases.
+            const MAX_TREND_ACCUMULATED: usize = 1_000_000;
+
             if let Some(hamlet) = effective_hamlet {
                 for event in current_events.iter() {
                     config.accumulated.push(Arc::clone(event));
+
+                    // Bound `accumulated` so it cannot grow without limit (audit:
+                    // unbounded growth → O(n²) re-scan + OOM). The trend aggregate
+                    // is windowed, so the correct bound is the WITHIN window: drop
+                    // events that have aged out of it in event-time, measured from
+                    // the event now being processed. Mirrors Hamlet's own windowing
+                    // (both share `window_ms`), so the count/sum below stay scoped
+                    // to exactly the window Hamlet reports trends over.
+                    if config.window_ms > 0 {
+                        let cutoff = event.timestamp
+                            - chrono::Duration::milliseconds(config.window_ms as i64);
+                        config.accumulated.retain(|e| e.timestamp >= cutoff);
+                    }
+                    if config.accumulated.len() > MAX_TREND_ACCUMULATED {
+                        let overflow = config.accumulated.len() - MAX_TREND_ACCUMULATED;
+                        config.accumulated.drain(0..overflow);
+                        warn!(
+                            "TrendAggregate: accumulated events hit the {} cap; \
+                             dropped {} oldest (window_ms={}). Narrow the WITHIN \
+                             window or reduce the event rate.",
+                            MAX_TREND_ACCUMULATED, overflow, config.window_ms
+                        );
+                    }
+
                     let results = hamlet.process(Arc::clone(event));
                     for agg_result in results {
                         // Only handle results for THIS stream's query

--- a/crates/varpulis-runtime/src/engine/types.rs
+++ b/crates/varpulis-runtime/src/engine/types.rs
@@ -320,6 +320,10 @@ pub struct TrendAggregateConfig {
     pub type_index_to_name: Vec<String>,
     /// Accumulated events across invocations (persists between execute_op calls)
     pub accumulated: Vec<SharedEvent>,
+    /// Trend window in milliseconds (the WITHIN duration). `accumulated` is
+    /// bounded to this event-time window so it cannot grow without limit.
+    /// 0 means "no WITHIN clause": a defensive count cap applies instead.
+    pub window_ms: u64,
 }
 
 /// Info for computing field-based aggregates at runtime.

--- a/crates/varpulis-runtime/tests/trend_aggregate_windowing_tests.rs
+++ b/crates/varpulis-runtime/tests/trend_aggregate_windowing_tests.rs
@@ -1,0 +1,84 @@
+//! Regression test for the TrendAggregate unbounded-`accumulated` fix.
+//!
+//! Audit finding (Phase 2, resource-safety): `TrendAggregateConfig.accumulated`
+//! grew without limit — every event was pushed and never evicted, so the
+//! per-event count/sum re-scan was O(n²) and memory grew forever (OOM). The op
+//! is windowed (WITHIN), so `accumulated` must be bounded to that same
+//! event-time window. Observable consequence: the field aggregates
+//! (`sum_trends`/`count_events`) reflect only the window, not all time.
+
+use tokio::sync::mpsc;
+use varpulis_core::Value;
+use varpulis_parser::parse;
+use varpulis_runtime::engine::Engine;
+use varpulis_runtime::event::Event;
+use varpulis_runtime::event_file::EventFileParser;
+
+async fn run_scenario(program_source: &str, events_source: &str) -> Vec<Event> {
+    let (tx, mut rx) = mpsc::channel::<Event>(1000);
+
+    let program = parse(program_source).expect("Failed to parse program");
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("Failed to load program");
+
+    let events = EventFileParser::parse(events_source).expect("Failed to parse events");
+    for timed_event in events {
+        engine
+            .process(timed_event.event)
+            .await
+            .expect("Failed to process event");
+    }
+
+    let mut results = Vec::new();
+    while let Ok(event) = rx.try_recv() {
+        results.push(event);
+    }
+    results
+}
+
+/// A trend aggregate's `accumulated` buffer — the source of its `sum_trends` /
+/// `count_events` field aggregates — must be bounded to the WITHIN window, not
+/// grow for all time. We prove it via the observable sum across a window
+/// boundary: batch A (price 100) at t=0s expires before batch B (price 1) at
+/// t=100s under a 1s window, so a batch-B emit must sum ONLY batch B.
+#[tokio::test]
+async fn trend_accumulated_is_bounded_to_within_window() {
+    let program = r"
+        stream WindowedSum = StockTick as first
+            -> all StockTick as rising
+            .within(1s)
+            .trend_aggregate(total: sum_trends(rising.price))
+            .emit(sum: total)
+    ";
+
+    let events = r#"
+        @0s   StockTick { symbol: "AAPL", price: 100.0 }
+        @0s   StockTick { symbol: "AAPL", price: 100.0 }
+        @0s   StockTick { symbol: "AAPL", price: 100.0 }
+        @100s StockTick { symbol: "AAPL", price: 1.0 }
+        @100s StockTick { symbol: "AAPL", price: 1.0 }
+        @100s StockTick { symbol: "AAPL", price: 1.0 }
+    "#;
+
+    let results = run_scenario(program, events).await;
+    assert!(!results.is_empty(), "trend aggregate should emit results");
+
+    let last_sum = results
+        .last()
+        .and_then(|r| r.data.get("sum"))
+        .and_then(|v| match v {
+            Value::Float(f) => Some(*f),
+            _ => None,
+        })
+        .expect("final result must carry a float `sum`");
+
+    // Windowed: batch A (300.0) has aged out; only batch B (3 * 1.0 = 3.0)
+    // remains. If `accumulated` were unbounded (the bug), batch A would leak
+    // into this emit and the sum would be 303.0.
+    assert!(
+        last_sum < 100.0,
+        "sum after the window boundary must reflect ONLY the current window \
+         (expected 3.0 from batch B); got {last_sum} — `accumulated` was not \
+         bounded to the WITHIN window, so all-time events leaked in"
+    );
+}


### PR DESCRIPTION
## Audit finding (Phase 2 — resource safety)

`TrendAggregateConfig.accumulated` pushed every event and **never evicted**. The per-event `count_events` / `sum_trends` re-scan over it was O(n²), and memory grew **without limit** — OOM on any long-running trend-aggregate stream. This is the `pipeline.rs` `accumulated` item flagged in the audit's unbounded-growth family.

## Fix

The op is windowed (`WITHIN`), and its Hamlet aggregator already reports trends over exactly that window — so the field aggregates computed *alongside* those trends must be scoped to the same window, not to all history.

- Carry `window_ms` (the `WITHIN` duration, already extracted for `HamletConfig` right next to the op's construction) into `TrendAggregateConfig`.
- Each event, drop `accumulated` events whose **event-time** has aged out of the window (`retain(|e| e.timestamp >= latest - window_ms)`). Mirrors Hamlet's own windowing, so `count_events`/`sum_trends` stay scoped to exactly the window Hamlet reports over.
- Hard **1M-count backstop**: even inside a huge window, a pathological high-rate stream can't exhaust memory — the oldest overflow is dropped, loudly (`warn!`).

`window_ms` defaults to 60s when no `WITHIN` is written (existing `extract_within_ms` behaviour), so eviction always applies. Not serialized (not in checkpoint state); single construction site.

## Fail-before / pass-after

Test `trend_accumulated_is_bounded_to_within_window`: batch A (price 100) at `@0s`, batch B (price 1) at `@100s`, `WITHIN 1s`. After the boundary the final emit must sum **only** batch B.

| | final emit `sum` | result |
|---|---|---|
| **pass-after** (windowed) | `3.0` (< 100) | ✅ ok |
| **fail-before** (eviction neutralized) | `303.0` — batch A leaked in | ❌ FAILED |

Existing `edge_hamlet_tests` (7) still green; scoped `clippy -D warnings` clean; nightly-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)