### PR TITLE
fix(connector-api): reject dynamic .to(topic) on sinks that can't route it, don't silently drop (audit HIGH)

### DIFF
--- a/crates/varpulis-connector-api/src/types.rs
+++ b/crates/varpulis-connector-api/src/types.rs
@@ -199,15 +199,24 @@ pub trait SinkConnector: Send + Sync {
     async fn send(&self, event: &Event) -> Result<(), ConnectorError>;
 
     /// Send a batch of events to a specific topic (for dynamic routing).
+    ///
+    /// The default **rejects** dynamic-topic routing rather than silently
+    /// delivering to the connector's fixed destination. Silently ignoring the
+    /// caller's `.to(topic)` intent ships data to the wrong place with no
+    /// signal — a connector that cannot honor a per-event topic must say so.
+    /// Connectors that *can* route by topic (Kafka topic, MQTT topic, NATS
+    /// subject, …) override this; the rest surface an explicit error the engine
+    /// logs (and can dead-letter) instead of dropping the routing intent.
     async fn send_to_topic(
         &self,
-        events: &[std::sync::Arc<Event>],
-        _topic: &str,
+        _events: &[std::sync::Arc<Event>],
+        topic: &str,
     ) -> Result<(), ConnectorError> {
-        for event in events {
-            self.send(event).await?;
-        }
-        Ok(())
+        Err(ConnectorError::SendFailed(format!(
+            "connector '{}' does not support dynamic topic routing \
+             (.to(\"{topic}\")); it delivers to its configured destination only",
+            self.name()
+        )))
     }
 
     /// Flush any internally buffered events.
@@ -315,6 +324,50 @@ pub enum ConnectorError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A connector with a single fixed destination that does NOT override
+    /// `send_to_topic` — exercises the trait default.
+    struct FixedDestinationSink;
+
+    #[async_trait]
+    impl SinkConnector for FixedDestinationSink {
+        fn name(&self) -> &str {
+            "fixed-dest"
+        }
+        async fn send(&self, _event: &Event) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+        async fn flush(&self) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+        async fn close(&self) -> Result<(), ConnectorError> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn send_to_topic_default_rejects_instead_of_silently_dropping() {
+        let sink = FixedDestinationSink;
+        let events = vec![std::sync::Arc::new(Event::new("E"))];
+        // A connector that cannot route by topic must fail loud, NOT silently
+        // deliver to its fixed destination — that would drop the caller's
+        // `.to(topic)` routing intent and send data to the wrong place.
+        let err = sink
+            .send_to_topic(&events, "dynamic-topic")
+            .await
+            .expect_err("default send_to_topic must reject dynamic routing");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("dynamic topic routing"),
+            "error should explain the rejection: {msg}"
+        );
+        assert!(
+            msg.contains("dynamic-topic"),
+            "error should name the requested topic: {msg}"
+        );
+        // The normal fixed-destination send path stays unaffected.
+        assert!(sink.send(&Event::new("E")).await.is_ok());
+    }
 
     #[test]
     fn connector_config_debug_redacts_url_and_property_secrets() {


### PR DESCRIPTION
## Audit finding (dynamic topic routing)

`SinkConnector::send_to_topic`'s default **silently delivered to the connector's fixed destination**, ignoring the caller's per-event `.to(topic)` routing intent. So `.to(topic)` on any sink that didn't override it (redis, elasticsearch, …) shipped events to the wrong place with no signal — the audit's *"dynamic topic silently dropped by every sink except Kafka."*

## Fix

Change the default to return an **explicit error** naming the connector and the requested topic, instead of silently routing to the fixed destination.

- Connectors that **can** route by topic — kafka (topic), mqtt (topic), nats (subject), syslog, slack — already override `send_to_topic` and are **unaffected**.
- The rest (redis, elasticsearch, and any future non-override sink) now **fail loud**.
- The engine's dynamic-topic dispatch already handles a per-topic send error gracefully (warns, marks the batch not-ok, can dead-letter) — so this surfaces as an observable failure, not a crash and not silent data loss.

### Scope is deliberately contained to connectors
Native `Console`/`File`/`Http` sinks implement the **separate** runtime `Sink` trait — they have a single destination where "topic" is meaningless, so their route-to-fixed default is left untouched (rejecting there would drop data). Verified the only caller of `send_to_topic` is the `SinkConnector`→`Sink` adapter, and no existing test relied on the old silent-route behavior.

## Fail-before / pass-after

`send_to_topic_default_rejects_instead_of_silently_dropping` (minimal non-override `SinkConnector`):

| | result |
|---|---|
| **pass-after** | default `send_to_topic` returns `Err` naming the topic ✅ |
| **fail-before** (default reverted to loop-send) | returns `Ok(())` → `expect_err` panics *"must reject dynamic routing"* ❌ |

connector-api suite (37) green; engine `dynamic_topic_routing_tests` (8) green; scoped `clippy -D warnings` clean; nightly-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)