### PR TITLE
fix(cli): bound VPL parse cost on the public pipeline-graph endpoints (audit HIGH, DoS)

### DIFF
--- a/crates/varpulis-cli/src/api.rs
+++ b/crates/varpulis-cli/src/api.rs
@@ -410,9 +410,18 @@ pub fn api_routes(
             "/api/v1/pipelines/{pipeline_id}/dlq/replay",
             post(handle_dlq_replay),
         )
-        // Pipeline graph (visual builder)
-        .route("/api/v1/pipeline/graph", post(handle_pipeline_to_graph))
-        .route("/api/v1/pipeline/generate", post(handle_graph_to_pipeline))
+        // Pipeline graph (visual builder) — unauthenticated stateless VPL↔graph
+        // transforms; body limits bound the parse cost (mirrors playground).
+        .route(
+            "/api/v1/pipeline/graph",
+            post(handle_pipeline_to_graph)
+                .layer(tower_http::limit::RequestBodyLimitLayer::new(256 * 1024)),
+        )
+        .route(
+            "/api/v1/pipeline/generate",
+            post(handle_graph_to_pipeline)
+                .layer(tower_http::limit::RequestBodyLimitLayer::new(1024 * 1024)),
+        )
         // Tenant admin routes
         .route(
             "/api/v1/tenants",
@@ -1667,7 +1676,20 @@ async fn handle_delete_tenant(
 // Pipeline Graph Handlers (Visual Builder)
 // =============================================================================
 
+/// Largest VPL source the graph endpoints will parse. These routes are
+/// unauthenticated by design (pure stateless VPL↔graph transforms exposing no
+/// state — same class as `/playground/validate`), so they must bound the parse
+/// cost to stay a non-DoS-able public utility. Mirrors playground's cap.
+const MAX_PIPELINE_VPL_BYTES: usize = 50_000;
+
 async fn handle_pipeline_to_graph(Json(body): Json<PipelineGraphRequest>) -> Response {
+    if body.vpl.len() > MAX_PIPELINE_VPL_BYTES {
+        return error_response(
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "payload_too_large",
+            &format!("VPL source exceeds maximum size of {MAX_PIPELINE_VPL_BYTES} bytes"),
+        );
+    }
     match varpulis_parser::parse(&body.vpl) {
         Ok(program) => {
             let graph = varpulis_runtime::engine::graph::program_to_graph(&program);
@@ -1768,6 +1790,27 @@ mod tests {
     use varpulis_runtime::tenant::{TenantManager, TenantQuota};
 
     use super::*;
+
+    #[tokio::test]
+    async fn pipeline_graph_rejects_oversized_vpl_before_parsing() {
+        // These endpoints are unauthenticated by design, so an oversized VPL
+        // body must be rejected up-front rather than handed to the parser —
+        // otherwise it's an unbounded-CPU DoS vector.
+        let oversized = format!("# {}\nstream AB = A -> B", "x".repeat(60_000));
+        let resp = handle_pipeline_to_graph(Json(PipelineGraphRequest { vpl: oversized })).await;
+        assert_eq!(
+            resp.status(),
+            StatusCode::PAYLOAD_TOO_LARGE,
+            "oversized VPL must be rejected before parsing"
+        );
+
+        // A normal-size, valid VPL still converts to a graph.
+        let ok = handle_pipeline_to_graph(Json(PipelineGraphRequest {
+            vpl: "stream AB = A -> B .emit(done: \"yes\")".to_string(),
+        }))
+        .await;
+        assert_eq!(ok.status(), StatusCode::OK, "normal VPL must still work");
+    }
 
     /// Test response wrapper for axum integration tests.
     struct TestResponse {


### PR DESCRIPTION
## Audit finding: `/pipeline/graph` unauthenticated — investigated + decided

**Decision: keep unauthenticated, close the real DoS vector.**

`/api/v1/pipeline/graph` and `/api/v1/pipeline/generate` are **pure stateless VPL↔graph transforms** (`parse(vpl) → graph JSON` and back). They take no `State`, touch no DB / pipelines / secrets, and mutate nothing — the same class as `/playground/validate`, which is intentionally public. The visual builder (stream-builder) calls them, sending `X-API-Key`, but there is nothing to protect: auth here would buy nothing and be inconsistent with the sibling endpoint. The genuine risk the "unauthenticated" flag points at is **CPU exhaustion from parsing an unbounded VPL body**.

## Fix — mirror `/playground/validate` exactly

- `MAX_PIPELINE_VPL_BYTES` (50 KiB) guard in `handle_pipeline_to_graph` → rejects oversized VPL with **413** before it reaches the parser (same as playground's `MAX_VPL_LENGTH`).
- `RequestBodyLimitLayer` on both routes (256 KiB / 1 MiB) as the transport backstop — matching playground's `handle_validate` / `handle_run` limits.

## Fail-before / pass-after

`pipeline_graph_rejects_oversized_vpl_before_parsing`:

| | result |
|---|---|
| **pass-after** | 60 KB VPL → `413 PAYLOAD_TOO_LARGE` (rejected pre-parse); normal VPL → `200 OK` |
| **fail-before** (guard neutralized) | oversized body reaches the parser, status ≠ 413 → assertion fails |

Full `api` test module (44) green; scoped `clippy -D warnings` clean; nightly-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)