### PR TITLE
feat(connector-redis): honor dynamic .to(topic) — publish to the requested channel/stream (audit HIGH)

### DIFF
--- a/crates/varpulis-connector-redis/src/lib.rs
+++ b/crates/varpulis-connector-redis/src/lib.rs
@@ -307,6 +307,24 @@ impl SinkConnector for RedisSink {
         Ok(())
     }
 
+    /// Honor dynamic `.to(topic)` by publishing to the requested channel
+    /// instead of the configured one (the default rejects unsupported routing).
+    async fn send_to_topic(
+        &self,
+        events: &[std::sync::Arc<Event>],
+        topic: &str,
+    ) -> Result<(), ConnectorError> {
+        let mut conn = self.conn.clone();
+        for event in events {
+            let payload = String::from_utf8(event.to_sink_payload())
+                .map_err(|e| ConnectorError::SendFailed(e.to_string()))?;
+            conn.publish::<_, _, ()>(topic, &payload)
+                .await
+                .map_err(|e| ConnectorError::SendFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     async fn flush(&self) -> Result<(), ConnectorError> {
         Ok(())
     }
@@ -664,6 +682,32 @@ impl SinkConnector for RedisStreamSink {
         Ok(())
     }
 
+    /// Honor dynamic `.to(topic)` by XADDing to the requested stream key
+    /// instead of the configured one (the default rejects unsupported routing).
+    async fn send_to_topic(
+        &self,
+        events: &[std::sync::Arc<Event>],
+        topic: &str,
+    ) -> Result<(), ConnectorError> {
+        let mut conn = self.conn.clone();
+        for event in events {
+            let payload = String::from_utf8(event.to_sink_payload())
+                .map_err(|e| ConnectorError::SendFailed(e.to_string()))?;
+            let mut cmd = redis::cmd("XADD");
+            cmd.arg(topic);
+            if let Some(max_len) = self.config.max_len {
+                cmd.arg("MAXLEN").arg("~").arg(max_len);
+            }
+            cmd.arg("*");
+            cmd.arg("data").arg(&payload);
+            cmd.arg("event_type").arg(event.event_type.as_ref());
+            cmd.query_async::<String>(&mut conn)
+                .await
+                .map_err(|e| ConnectorError::SendFailed(e.to_string()))?;
+        }
+        Ok(())
+    }
+
     async fn flush(&self) -> Result<(), ConnectorError> {
         Ok(())
     }
@@ -720,6 +764,16 @@ impl SinkConnector for RedisStreamSinkStub {
         guard.as_ref().unwrap().send(event).await
     }
 
+    async fn send_to_topic(
+        &self,
+        events: &[std::sync::Arc<Event>],
+        topic: &str,
+    ) -> Result<(), ConnectorError> {
+        self.ensure_connected().await?;
+        let guard = self.inner.lock().await;
+        guard.as_ref().unwrap().send_to_topic(events, topic).await
+    }
+
     async fn flush(&self) -> Result<(), ConnectorError> {
         let guard = self.inner.lock().await;
         if let Some(ref sink) = *guard {
@@ -742,6 +796,63 @@ impl SinkConnector for RedisStreamSinkStub {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// RedisSink must honor a dynamic `.to(topic)` by publishing to the
+    /// requested channel, not the configured one (and not reject/drop it).
+    /// Needs a reachable Redis; skips gracefully when none is available so CI
+    /// without a broker stays green. Point it elsewhere with
+    /// `VARPULIS_TEST_REDIS_URL` (defaults to the local test container on 6390).
+    #[tokio::test]
+    async fn redis_sink_honors_dynamic_topic_publishes_to_requested_channel() {
+        use std::time::Duration;
+
+        let url = std::env::var("VARPULIS_TEST_REDIS_URL")
+            .unwrap_or_else(|_| "redis://127.0.0.1:6390".to_string());
+
+        let Ok(client) = redis::Client::open(url.as_str()) else {
+            eprintln!("[skip] redis client open failed for {url}");
+            return;
+        };
+        let mut pubsub = match client.get_async_pubsub().await {
+            Ok(p) => p,
+            Err(e) => {
+                eprintln!("[skip] redis not reachable at {url}: {e}");
+                return;
+            }
+        };
+        let dyn_channel = "varpulis-dyn-topic-test-channel";
+        if pubsub.subscribe(dyn_channel).await.is_err() {
+            eprintln!("[skip] redis subscribe failed");
+            return;
+        }
+        let mut messages = pubsub.on_message();
+
+        // Sink is configured with a DIFFERENT fixed channel; the dynamic route
+        // must win over it.
+        let config = RedisConfig::new(&url, "fixed-channel-should-not-receive");
+        let sink = match RedisSink::new("dyn-topic-test-sink", config).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[skip] redis sink connect failed: {e}");
+                return;
+            }
+        };
+
+        let event = Arc::new(Event::new("DynEvt").with_field("marker", "honor-me-42"));
+        sink.send_to_topic(std::slice::from_ref(&event), dyn_channel)
+            .await
+            .expect("send_to_topic must honor the dynamic channel, not reject or drop it");
+
+        let msg = tokio::time::timeout(Duration::from_secs(5), messages.next())
+            .await
+            .expect("timed out waiting for a message on the dynamic channel")
+            .expect("pubsub stream ended unexpectedly");
+        let payload: String = msg.get_payload().expect("payload should decode");
+        assert!(
+            payload.contains("honor-me-42"),
+            "event must be published to the dynamic channel; payload: {payload}"
+        );
+    }
 
     #[test]
     fn redis_config_debug_redacts_url_password() {


### PR DESCRIPTION
## Follow-up to #205 (dynamic-topic reject)

#205 made the `SinkConnector` default **reject** dynamic `.to(topic)` instead of silently dropping it. Redis is a sink where a per-event topic **is** meaningful (a channel / stream key), so the right end state is to *honor* it — same as kafka/mqtt/nats already do.

## Fix — override `send_to_topic` on all three redis sinks

- **RedisSink** (pub/sub) → `PUBLISH` to the requested channel instead of the fixed `config.channel`.
- **RedisStreamSink** (XADD) → `XADD` to the requested stream key instead of the fixed `config.stream_key` (MAXLEN trimming preserved).
- **RedisStreamSinkStub** → connect-then-delegate to the inner sink's override.

`.to(expr)` on a redis sink now routes each event to its evaluated channel/stream.

## Fail-before / pass-after — real Redis, broker-skip-graceful

`redis_sink_honors_dynamic_topic_publishes_to_requested_channel`: subscribe to a dynamic channel, configure the sink with a **different** fixed channel, `send_to_topic` to the dynamic one, assert arrival.

| | result |
|---|---|
| **pass-after** | event received on the dynamic channel ✅ |
| **fail-before** (override routes to fixed channel) | dynamic subscriber gets nothing → *"timed out waiting for a message on the dynamic channel"* ❌ |

Test skips gracefully when no broker is reachable (CI stays green); set `VARPULIS_TEST_REDIS_URL` to point elsewhere. Full redis suite (17) green; scoped `clippy -D warnings` clean.

> Note: Elasticsearch (dynamic index) is the remaining sink in this class — separate PR (heavier container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)