### PR TITLE
perf(engine): skip unreferenced per-alias structures in the SequenceMatch build (audit)

### DIFF
--- a/crates/varpulis-runtime/src/engine/compilation.rs
+++ b/crates/varpulis-runtime/src/engine/compilation.rs
@@ -1665,8 +1665,13 @@ impl Engine {
             matches!(source, StreamSource::Ident(name) if self.patterns.contains_key(name));
 
         if !followed_by_clauses.is_empty() || matches!(source, StreamSource::Sequence(_)) {
-            // Add Sequence operation marker at the beginning
-            runtime_ops.insert(0, RuntimeOp::Sequence);
+            // Add Sequence operation marker at the beginning.
+            // `runtime_ops` currently holds exactly the DOWNSTREAM ops (the
+            // Sequence op is prepended below), so analyze them first to learn
+            // which Kleene aliases are actually referenced and gate the
+            // expensive per-alias build in pipeline.rs on the result.
+            let seq_cfg = super::sequence_analysis::analyze_downstream_alias_needs(runtime_ops);
+            runtime_ops.insert(0, RuntimeOp::Sequence(seq_cfg));
 
             // Create stream resolver for derived streams
             let stream_resolver = |name: &str| -> Option<compiler::DerivedStreamInfo> {
@@ -1752,8 +1757,11 @@ impl Engine {
                 *partition_key = Some(field.clone());
             }
 
-            // Add Sequence operation marker
-            runtime_ops.insert(0, RuntimeOp::Sequence);
+            // Add Sequence operation marker.
+            // `runtime_ops` currently holds exactly the DOWNSTREAM ops, so
+            // analyze them first to gate the expensive per-alias build.
+            let seq_cfg = super::sequence_analysis::analyze_downstream_alias_needs(runtime_ops);
+            runtime_ops.insert(0, RuntimeOp::Sequence(seq_cfg));
 
             // Compile the named pattern expression to a SASE pattern
             if let Some(pattern) =

--- a/crates/varpulis-runtime/src/engine/mod.rs
+++ b/crates/varpulis-runtime/src/engine/mod.rs
@@ -18,6 +18,7 @@ pub mod physical_plan;
 mod pipeline;
 pub mod planner;
 mod router;
+mod sequence_analysis;
 #[cfg(feature = "async-runtime")]
 mod sink_factory;
 pub mod topology;

--- a/crates/varpulis-runtime/src/engine/pipeline.rs
+++ b/crates/varpulis-runtime/src/engine/pipeline.rs
@@ -40,6 +40,29 @@ fn empty_vars() -> &'static FxHashMap<String, Value> {
     &EMPTY_VARS
 }
 
+/// Build the capped `_events_{alias}` array for a Kleene alias: one
+/// `Value::Map` per captured event (fields deep-cloned), truncated to at most
+/// `cap` elements.
+///
+/// Extracted from the `Sequence` arm so the cap is unit-testable: a Kleene
+/// closure is bounded by SASE's `MAX_KLEENE_EVENTS` (20), which is far below
+/// `crate::limits::MAX_ARRAY_ELEMENTS`, so the truncation cannot be exercised
+/// end-to-end through the normal VPL path. The cap is a defensive backstop for
+/// any code path that groups more entries under one alias.
+fn build_events_array(events: &[&Event], cap: usize) -> Vec<Value> {
+    events
+        .iter()
+        .take(cap)
+        .map(|ev| {
+            let mut map = IndexMap::with_hasher(FxBuildHasher);
+            for (k, v) in &ev.data {
+                map.insert(k.clone(), v.clone());
+            }
+            Value::Map(Box::new(map))
+        })
+        .collect()
+}
+
 /// Flags indicating which operation types to skip during pipeline execution.
 /// Different entry points (normal stream, join result, post-window) skip different ops.
 #[derive(Default, Clone, Copy)]
@@ -141,7 +164,7 @@ pub async fn execute_pipeline(
 
         // Don't exit early if the Forecast op hasn't run yet — it needs to
         // learn from every event even when Sequence produces no match.
-        if current_events.is_empty() && !(has_forecast && matches!(op, RuntimeOp::Sequence)) {
+        if current_events.is_empty() && !(has_forecast && matches!(op, RuntimeOp::Sequence(_))) {
             return Ok(StreamProcessResult {
                 emitted_events,
                 output_events: vec![],
@@ -193,7 +216,7 @@ const fn should_skip_op(op: &RuntimeOp, flags: SkipFlags) -> bool {
         RuntimeOp::Print(_) | RuntimeOp::Log(_) => flags.print_log,
 
         // Sequence/Pattern/TrendAggregate/Forecast skipping
-        RuntimeOp::Sequence
+        RuntimeOp::Sequence(_)
         | RuntimeOp::Pattern(_)
         | RuntimeOp::TrendAggregate(_)
         | RuntimeOp::Forecast(_) => flags.sequence_pattern,
@@ -862,7 +885,7 @@ fn execute_op_common(
             }
         }
 
-        RuntimeOp::Sequence => {
+        RuntimeOp::Sequence(seq_cfg) => {
             let mut sequence_results = Vec::with_capacity(8);
 
             if let Some(ref mut sase) = sase_engine {
@@ -920,25 +943,37 @@ fn execute_op_common(
                                 .data
                                 .insert(format!("_count_{alias}").into(), Value::Int(count as i64));
 
-                            // _events_alias: Value::Array of Value::Map (one map per captured event)
-                            // Used by the evaluator to support array-style access:
-                            // alias.LEN, alias[i], alias[i].field, collect(alias.field)
-                            let events_array: Vec<Value> = events
-                                .iter()
-                                .map(|ev| {
-                                    let mut map = IndexMap::with_hasher(FxBuildHasher);
-                                    for (k, v) in &ev.data {
-                                        map.insert(k.clone(), v.clone());
-                                    }
-                                    Value::Map(Box::new(map))
-                                })
-                                .collect();
-                            seq_event.data.insert(
-                                format!("_events_{alias}").into(),
-                                Value::array(events_array),
-                            );
+                            // _events_alias: Value::Array of Value::Map (one map
+                            // per captured event). The evaluator reads it only for
+                            // positional access (`alias[i]`) and `collect(alias…)`,
+                            // so build it only when the compile-time analysis found
+                            // this alias referenced that way. Building it for every
+                            // match is O(events) memory per match and O(events²)
+                            // over a Kleene run — the OOM this gate prevents.
+                            if seq_cfg.aliases_needing_events.contains(*alias) {
+                                // Cap the materialized array so a runaway Kleene
+                                // closure cannot allocate without bound. The true
+                                // count is still reported via `_count_{alias}`;
+                                // only positional access / collect is truncated.
+                                let cap = crate::limits::MAX_ARRAY_ELEMENTS;
+                                if count > cap {
+                                    tracing::warn!(
+                                        alias = %alias,
+                                        count,
+                                        cap,
+                                        "Kleene alias captured more events than the per-match \
+                                         array cap; positional access / collect(...) is truncated \
+                                         to the cap (the _count_ field still reports the true count)"
+                                    );
+                                }
+                                seq_event.data.insert(
+                                    format!("_events_{alias}").into(),
+                                    Value::array(build_events_array(events, cap)),
+                                );
+                            }
 
-                            // first(alias) and last(alias) as Value::Map
+                            // first(alias) and last(alias) as Value::Map (cheap:
+                            // one map each) — always built.
                             if let Some(first_ev) = events.first() {
                                 let mut map = IndexMap::with_hasher(FxBuildHasher);
                                 for (k, v) in &first_ev.data {
@@ -960,68 +995,85 @@ fn execute_op_common(
                                 );
                             }
 
-                            // Collect all unique field names across events
-                            let mut all_fields: Vec<Arc<str>> = Vec::new();
-                            for ev in events {
-                                for (k, _) in &ev.data {
-                                    if !all_fields.iter().any(|f| f == k) {
-                                        all_fields.push(k.clone());
-                                    }
-                                }
-                            }
-
-                            // Pre-compute aggregates for each field
-                            for field in &all_fields {
-                                // Numeric aggregates (sum, avg, min, max)
-                                let numeric_vals: Vec<f64> = events
-                                    .iter()
-                                    .filter_map(|ev| ev.get(field.as_ref()))
-                                    .filter_map(|v| match v {
-                                        Value::Float(f) => Some(*f),
-                                        Value::Int(i) => Some(*i as f64),
-                                        _ => None,
-                                    })
-                                    .collect();
-
-                                if !numeric_vals.is_empty() {
-                                    let sum: f64 = numeric_vals.iter().sum();
-                                    let avg = sum / numeric_vals.len() as f64;
-                                    let min =
-                                        numeric_vals.iter().copied().fold(f64::INFINITY, f64::min);
-                                    let max = numeric_vals
-                                        .iter()
-                                        .copied()
-                                        .fold(f64::NEG_INFINITY, f64::max);
-
-                                    seq_event.data.insert(
-                                        format!("_agg_sum_{alias}_{field}").into(),
-                                        Value::Float(sum),
-                                    );
-                                    seq_event.data.insert(
-                                        format!("_agg_avg_{alias}_{field}").into(),
-                                        Value::Float(avg),
-                                    );
-                                    seq_event.data.insert(
-                                        format!("_agg_min_{alias}_{field}").into(),
-                                        Value::Float(min),
-                                    );
-                                    seq_event.data.insert(
-                                        format!("_agg_max_{alias}_{field}").into(),
-                                        Value::Float(max),
-                                    );
-                                }
-
-                                // Distinct count (works for all value types)
-                                let mut distinct = std::collections::HashSet::new();
+                            // Numeric aggregates (sum/avg/min/max) and the distinct
+                            // count are read only by
+                            // `sum|avg|min|max|distinct_count(alias.field)`, so
+                            // build them only when the compile-time analysis found
+                            // this alias referenced that way. The all_fields +
+                            // per-field loop is itself O(events) per match, so
+                            // skipping it removes a big part of the O(events²).
+                            if seq_cfg.aliases_needing_aggs.contains(*alias) {
+                                // Collect all unique field names across events
+                                let mut all_fields: Vec<Arc<str>> = Vec::new();
                                 for ev in events {
-                                    if let Some(v) = ev.get(field.as_ref()) {
-                                        distinct.insert(format!("{v:?}"));
+                                    for (k, _) in &ev.data {
+                                        if !all_fields.iter().any(|f| f == k) {
+                                            all_fields.push(k.clone());
+                                        }
                                     }
                                 }
-                                seq_event.data.insert(
-                                    format!("_agg_distinct_{alias}_{field}").into(),
-                                    Value::Int(distinct.len() as i64),
-                                );
+
+                                // Pre-compute aggregates for each field
+                                for field in &all_fields {
+                                    // Numeric aggregates (sum, avg, min, max)
+                                    let numeric_vals: Vec<f64> = events
+                                        .iter()
+                                        .filter_map(|ev| ev.get(field.as_ref()))
+                                        .filter_map(|v| match v {
+                                            Value::Float(f) => Some(*f),
+                                            Value::Int(i) => Some(*i as f64),
+                                            _ => None,
+                                        })
+                                        .collect();
+
+                                    if !numeric_vals.is_empty() {
+                                        let sum: f64 = numeric_vals.iter().sum();
+                                        let avg = sum / numeric_vals.len() as f64;
+                                        let min = numeric_vals
+                                            .iter()
+                                            .copied()
+                                            .fold(f64::INFINITY, f64::min);
+                                        let max = numeric_vals
+                                            .iter()
+                                            .copied()
+                                            .fold(f64::NEG_INFINITY, f64::max);
+
+                                        seq_event.data.insert(
+                                            format!("_agg_sum_{alias}_{field}").into(),
+                                            Value::Float(sum),
+                                        );
+                                        seq_event.data.insert(
+                                            format!("_agg_avg_{alias}_{field}").into(),
+                                            Value::Float(avg),
+                                        );
+                                        seq_event.data.insert(
+                                            format!("_agg_min_{alias}_{field}").into(),
+                                            Value::Float(min),
+                                        );
+                                        seq_event.data.insert(
+                                            format!("_agg_max_{alias}_{field}").into(),
+                                            Value::Float(max),
+                                        );
+                                    }
+
+                                    // Distinct count (works for all value types).
+                                    // `Value` implements a consistent `Hash + Eq`
+                                    // (NaN==NaN, -0.0==0.0), so borrow each value
+                                    // into a `HashSet<&Value>` rather than
+                                    // allocating a `format!("{v:?}")` String per
+                                    // value.
+                                    let mut distinct: std::collections::HashSet<&Value> =
+                                        std::collections::HashSet::new();
+                                    for ev in events {
+                                        if let Some(v) = ev.get(field.as_ref()) {
+                                            distinct.insert(v);
+                                        }
+                                    }
+                                    seq_event.data.insert(
+                                        format!("_agg_distinct_{alias}_{field}").into(),
+                                        Value::Int(distinct.len() as i64),
+                                    );
+                                }
                             }
                         }
 
@@ -1524,7 +1576,7 @@ pub fn execute_pipeline_sync(
         )?;
 
         // Don't exit early if the Forecast op hasn't run yet
-        if current_events.is_empty() && !(has_forecast && matches!(op, RuntimeOp::Sequence)) {
+        if current_events.is_empty() && !(has_forecast && matches!(op, RuntimeOp::Sequence(_))) {
             return Ok(StreamProcessResult {
                 emitted_events,
                 output_events: vec![],
@@ -1584,4 +1636,47 @@ fn execute_op_sync(
         emitted_events,
         functions,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use varpulis_core::Value;
+
+    use super::build_events_array;
+    use crate::event::Event;
+
+    fn tick(price: f64) -> Event {
+        Event::new("Tick").with_field("price", price)
+    }
+
+    /// The `_events_{alias}` array is truncated to the cap. This is the
+    /// resource-safety backstop: a Kleene closure is bounded by SASE's
+    /// `MAX_KLEENE_EVENTS` (20), far below `MAX_ARRAY_ELEMENTS`, so the cap
+    /// cannot be reached end-to-end and is verified here instead.
+    ///
+    /// Fail-before: removing `.take(cap)` in `build_events_array` returns all
+    /// `cap + 5` elements and this assertion fails. Pass-after: it is capped.
+    #[test]
+    fn build_events_array_truncates_at_cap() {
+        let cap = crate::limits::MAX_ARRAY_ELEMENTS;
+        let evs: Vec<Event> = (0..(cap + 5)).map(|i| tick(i as f64)).collect();
+        let refs: Vec<&Event> = evs.iter().collect();
+        let arr = build_events_array(&refs, cap);
+        assert_eq!(arr.len(), cap, "array must be capped at MAX_ARRAY_ELEMENTS");
+        // Truncation keeps the FIRST `cap` events so positional access (alias[i]
+        // for small i) stays valid.
+        match &arr[0] {
+            Value::Map(m) => assert_eq!(m.get("price"), Some(&Value::Float(0.0))),
+            other => panic!("expected Map element, got {other:?}"),
+        }
+    }
+
+    /// Below the cap, every captured event is materialized (no truncation).
+    #[test]
+    fn build_events_array_keeps_all_under_cap() {
+        let evs: Vec<Event> = (0..5).map(|i| tick(i as f64)).collect();
+        let refs: Vec<&Event> = evs.iter().collect();
+        let arr = build_events_array(&refs, crate::limits::MAX_ARRAY_ELEMENTS);
+        assert_eq!(arr.len(), 5);
+    }
 }

--- a/crates/varpulis-runtime/src/engine/sequence_analysis.rs
+++ b/crates/varpulis-runtime/src/engine/sequence_analysis.rs
@@ -1,0 +1,367 @@
+//! Compile-time analysis of which Kleene aliases a sequence pipeline references.
+//!
+//! When a Kleene/sequence match completes, `pipeline.rs` can build several
+//! per-alias structures for the emitted `SequenceMatch` event:
+//!
+//! - `_events_{alias}`: a `Value::Array` of `Value::Map`, one deep-cloned map
+//!   per captured event. This is O(events) memory per match and, because a
+//!   Kleene closure emits one incremental match per event, O(events²) over a
+//!   run — the source of the OOM this module exists to avoid.
+//! - `_agg_{sum,avg,min,max}_{alias}_{field}` and `_agg_distinct_{alias}_{field}`:
+//!   per-field aggregates, another O(events) scan per match.
+//!
+//! The evaluator (`evaluator.rs`) only ever reads those structures through a
+//! small, fixed set of syntactic forms:
+//!
+//! - the `_events_{alias}` array via positional index `alias[i]`, via
+//!   `collect(alias.field)`, or via bare `collect(alias)`;
+//! - the aggregates via `sum|avg|min|max|distinct_count(alias.field)`.
+//!
+//! So we can walk the downstream operators at compile time, record which
+//! aliases appear in each form, and let the builder skip everything unused.
+//!
+//! **Correctness bias:** over-inclusion is safe (we build something nothing
+//! reads); under-inclusion drops a field a pipeline reads and is a bug. The
+//! walk is therefore exhaustive and conservative — the `match` arms carry no
+//! `_` wildcard so that adding a new [`RuntimeOp`] or [`Expr`] variant is a
+//! compile error here rather than a silent miss.
+
+use varpulis_core::ast::{Arg, Expr};
+
+use super::types::{RuntimeOp, SequenceMatchConfig, TopicSpec};
+
+/// Analyze the downstream operators of a sequence stream and return which
+/// aliases need the expensive per-alias structures built.
+///
+/// `ops` is the operator list *after* the `Sequence` op (at both call sites in
+/// `compilation.rs` the analysis runs before `runtime_ops.insert(0, …)`, so the
+/// slice already contains exactly the downstream ops).
+pub(super) fn analyze_downstream_alias_needs(ops: &[RuntimeOp]) -> SequenceMatchConfig {
+    let mut cfg = SequenceMatchConfig::default();
+    for op in ops {
+        visit_op(op, &mut cfg);
+    }
+    cfg
+}
+
+/// Extract the inner expression from a function argument (positional or named).
+#[inline]
+fn arg_expr(arg: &Arg) -> &Expr {
+    match arg {
+        Arg::Positional(e) | Arg::Named(_, e) => e,
+    }
+}
+
+/// Walk every expression carried by a single operator.
+///
+/// Every [`RuntimeOp`] variant is listed explicitly (no `_` arm) so a new
+/// variant forces a decision here instead of silently escaping the analysis.
+fn visit_op(op: &RuntimeOp, cfg: &mut SequenceMatchConfig) {
+    match op {
+        // --- Operators carrying user expressions we must walk ------------------
+        RuntimeOp::WhereExpr(expr) | RuntimeOp::Having(expr) | RuntimeOp::Process(expr) => {
+            visit_expr(expr, cfg);
+        }
+        RuntimeOp::Select(config) => {
+            for (_, expr) in &config.fields {
+                visit_expr(expr, cfg);
+            }
+        }
+        RuntimeOp::EmitExpr(config) => {
+            for (_, expr) in &config.fields {
+                visit_expr(expr, cfg);
+            }
+        }
+        RuntimeOp::Print(config) => {
+            for expr in &config.exprs {
+                visit_expr(expr, cfg);
+            }
+        }
+        RuntimeOp::Pattern(config) => visit_expr(&config.matcher, cfg),
+        RuntimeOp::Enrich(config) => visit_expr(&config.key_expr, cfg),
+        RuntimeOp::Distinct(state) => {
+            if let Some(expr) = &state.expr {
+                visit_expr(expr, cfg);
+            }
+        }
+        RuntimeOp::To(config) => {
+            if let Some(TopicSpec::Dynamic(expr)) = &config.topic {
+                visit_expr(expr, cfg);
+            }
+        }
+
+        // --- Operators with no downstream-readable expressions -----------------
+        // `WhereClosure` is an opaque boxed `Fn` and cannot be introspected; a
+        // sequence filter compiled to a closure never reads the `_events_`/`_agg_`
+        // structures (it filters raw captured events), so skipping it is safe.
+        // `Emit` only carries source-field names / literals, not expressions.
+        RuntimeOp::WhereClosure(_)
+        | RuntimeOp::Window(_)
+        | RuntimeOp::PartitionedWindow(_)
+        | RuntimeOp::PartitionedSlidingCountWindow(_)
+        | RuntimeOp::Aggregate(_)
+        | RuntimeOp::PartitionedAggregate(_)
+        | RuntimeOp::Emit(_)
+        | RuntimeOp::Log(_)
+        | RuntimeOp::Sequence(_)
+        | RuntimeOp::TrendAggregate(_)
+        | RuntimeOp::Score(_)
+        | RuntimeOp::Forecast(_)
+        | RuntimeOp::Alert(_)
+        | RuntimeOp::Limit(_) => {}
+
+        #[cfg(feature = "arrow")]
+        RuntimeOp::PartitionedWindowedColumnarAggregate(_)
+        | RuntimeOp::WindowedColumnarAggregate(_) => {}
+
+        #[cfg(feature = "async-runtime")]
+        RuntimeOp::Concurrent(_) => {}
+    }
+}
+
+/// Recursively walk an expression tree, recording alias references and
+/// recursing into every sub-expression.
+///
+/// Every [`Expr`] variant is listed explicitly (no `_` arm) so a new variant
+/// forces a decision here instead of silently escaping the analysis.
+fn visit_expr(expr: &Expr, cfg: &mut SequenceMatchConfig) {
+    match expr {
+        // `alias[i]` → positional access, resolved against `_events_{alias}`.
+        Expr::Index {
+            expr: container,
+            index,
+        } => {
+            if let Expr::Ident(name) = container.as_ref() {
+                cfg.aliases_needing_events.insert(name.clone());
+            }
+            visit_expr(container, cfg);
+            visit_expr(index, cfg);
+        }
+
+        // `collect(alias.field)` / `collect(alias)` read the `_events_{alias}`
+        // array; `sum|avg|min|max|distinct_count(alias.field)` read the
+        // `_agg_*` aggregates. Anything else recurses normally.
+        Expr::Call { func, args } => {
+            if let Expr::Ident(fname) = func.as_ref() {
+                if let Some(first) = args.first() {
+                    let arg = arg_expr(first);
+                    match fname.as_str() {
+                        "collect" => match arg {
+                            Expr::Member { expr: obj, .. } => {
+                                if let Expr::Ident(name) = obj.as_ref() {
+                                    cfg.aliases_needing_events.insert(name.clone());
+                                }
+                            }
+                            // `collect(alias)` without a member returns the whole
+                            // array (see evaluator). Detect it too — over-include
+                            // rather than under-include.
+                            Expr::Ident(name) => {
+                                cfg.aliases_needing_events.insert(name.clone());
+                            }
+                            _ => {}
+                        },
+                        "sum" | "avg" | "min" | "max" | "distinct_count" => {
+                            if let Expr::Member { expr: obj, .. } = arg {
+                                if let Expr::Ident(name) = obj.as_ref() {
+                                    cfg.aliases_needing_aggs.insert(name.clone());
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                }
+            }
+            visit_expr(func, cfg);
+            for a in args {
+                visit_expr(arg_expr(a), cfg);
+            }
+        }
+
+        // Leaves: nothing to recurse into. A bare `Ident(alias)` does NOT read
+        // any `_events_`/`_agg_` structure (the evaluator resolves it from
+        // bindings/event data), so it triggers no inclusion.
+        Expr::Null
+        | Expr::Bool(_)
+        | Expr::Int(_)
+        | Expr::Float(_)
+        | Expr::Str(_)
+        | Expr::Duration(_)
+        | Expr::Timestamp(_)
+        | Expr::Ident(_) => {}
+
+        // Composite variants: recurse into every sub-expression.
+        Expr::Array(items) => {
+            for e in items {
+                visit_expr(e, cfg);
+            }
+        }
+        Expr::Map(entries) => {
+            for (_, e) in entries {
+                visit_expr(e, cfg);
+            }
+        }
+        Expr::Binary { left, right, .. } => {
+            visit_expr(left, cfg);
+            visit_expr(right, cfg);
+        }
+        Expr::Unary { expr: inner, .. }
+        | Expr::Member { expr: inner, .. }
+        | Expr::OptionalMember { expr: inner, .. } => visit_expr(inner, cfg),
+        Expr::Slice {
+            expr: inner,
+            start,
+            end,
+        } => {
+            visit_expr(inner, cfg);
+            if let Some(s) = start {
+                visit_expr(s, cfg);
+            }
+            if let Some(e) = end {
+                visit_expr(e, cfg);
+            }
+        }
+        Expr::Lambda { body, .. } => visit_expr(body, cfg),
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            visit_expr(cond, cfg);
+            visit_expr(then_branch, cfg);
+            visit_expr(else_branch, cfg);
+        }
+        Expr::Coalesce {
+            expr: inner,
+            default,
+        } => {
+            visit_expr(inner, cfg);
+            visit_expr(default, cfg);
+        }
+        Expr::Range { start, end, .. } => {
+            visit_expr(start, cfg);
+            visit_expr(end, cfg);
+        }
+        Expr::Block { stmts, result } => {
+            for (_, _, value, _) in stmts {
+                visit_expr(value, cfg);
+            }
+            visit_expr(result, cfg);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ident(name: &str) -> Expr {
+        Expr::Ident(name.to_string())
+    }
+
+    fn member(obj: Expr, m: &str) -> Expr {
+        Expr::Member {
+            expr: Box::new(obj),
+            member: m.to_string(),
+        }
+    }
+
+    fn call(fname: &str, arg: Expr) -> Expr {
+        Expr::Call {
+            func: Box::new(ident(fname)),
+            args: vec![Arg::Positional(arg)],
+        }
+    }
+
+    fn analyze(expr: &Expr) -> SequenceMatchConfig {
+        let mut cfg = SequenceMatchConfig::default();
+        visit_expr(expr, &mut cfg);
+        cfg
+    }
+
+    #[test]
+    fn index_marks_events() {
+        // tick[0]
+        let e = Expr::Index {
+            expr: Box::new(ident("tick")),
+            index: Box::new(Expr::Int(0)),
+        };
+        let cfg = analyze(&e);
+        assert!(cfg.aliases_needing_events.contains("tick"));
+        assert!(cfg.aliases_needing_aggs.is_empty());
+    }
+
+    #[test]
+    fn collect_member_marks_events() {
+        // collect(tick.price)
+        let cfg = analyze(&call("collect", member(ident("tick"), "price")));
+        assert!(cfg.aliases_needing_events.contains("tick"));
+    }
+
+    #[test]
+    fn collect_bare_marks_events() {
+        // collect(tick)
+        let cfg = analyze(&call("collect", ident("tick")));
+        assert!(cfg.aliases_needing_events.contains("tick"));
+    }
+
+    #[test]
+    fn aggs_mark_aggs_only() {
+        for f in ["sum", "avg", "min", "max", "distinct_count"] {
+            let cfg = analyze(&call(f, member(ident("tick"), "price")));
+            assert!(cfg.aliases_needing_aggs.contains("tick"), "func {f}");
+            assert!(
+                cfg.aliases_needing_events.is_empty(),
+                "func {f} should not need events"
+            );
+        }
+    }
+
+    #[test]
+    fn count_first_last_len_need_nothing() {
+        // count(tick), first(tick), last(tick) read always-built scalars.
+        for f in ["count", "first", "last"] {
+            let cfg = analyze(&call(f, ident("tick")));
+            assert!(cfg.aliases_needing_events.is_empty(), "func {f}");
+            assert!(cfg.aliases_needing_aggs.is_empty(), "func {f}");
+        }
+        // tick.LEN reads _count_{alias} (always built).
+        let cfg = analyze(&member(ident("tick"), "LEN"));
+        assert!(cfg.aliases_needing_events.is_empty());
+        assert!(cfg.aliases_needing_aggs.is_empty());
+    }
+
+    #[test]
+    fn bare_ident_needs_nothing() {
+        let cfg = analyze(&ident("tick"));
+        assert!(cfg.aliases_needing_events.is_empty());
+        assert!(cfg.aliases_needing_aggs.is_empty());
+    }
+
+    #[test]
+    fn nested_collect_inside_user_call_is_found() {
+        // myfunc(collect(tick.price))
+        let inner = call("collect", member(ident("tick"), "price"));
+        let outer = Expr::Call {
+            func: Box::new(ident("myfunc")),
+            args: vec![Arg::Positional(inner)],
+        };
+        let cfg = analyze(&outer);
+        assert!(cfg.aliases_needing_events.contains("tick"));
+    }
+
+    #[test]
+    fn deep_nesting_binary_if_index() {
+        // if cond then tick[i] else sum(other.v)
+        let e = Expr::If {
+            cond: Box::new(Expr::Bool(true)),
+            then_branch: Box::new(Expr::Index {
+                expr: Box::new(ident("tick")),
+                index: Box::new(ident("i")),
+            }),
+            else_branch: Box::new(call("sum", member(ident("other"), "v"))),
+        };
+        let cfg = analyze(&e);
+        assert!(cfg.aliases_needing_events.contains("tick"));
+        assert!(cfg.aliases_needing_aggs.contains("other"));
+    }
+}

--- a/crates/varpulis-runtime/src/engine/types.rs
+++ b/crates/varpulis-runtime/src/engine/types.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use indexmap::IndexMap;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use varpulis_core::ast::{ConfigValue, Expr, SasePatternExpr};
 use varpulis_core::Value;
 
@@ -180,6 +180,36 @@ pub struct MergeSource {
     pub filter: Option<varpulis_core::ast::Expr>,
 }
 
+/// Compile-time analysis carried on [`RuntimeOp::Sequence`]: which Kleene
+/// aliases the downstream pipeline actually references.
+///
+/// When a Kleene/sequence match completes, the builder in `pipeline.rs` used to
+/// construct — for every match and every alias — a `_events_{alias}` array (a
+/// deep clone of every captured event) plus per-field numeric aggregates and a
+/// distinct count. For a closure like `News -> all Tick as tick` fed N events
+/// that is O(N) memory per match and O(N²) overall, which OOMs on long runs.
+///
+/// Most of that is dead: the evaluator only reads the `_events_{alias}` array
+/// for positional access (`alias[i]`) or `collect(alias.field)`, and only reads
+/// the aggregates for `sum/avg/min/max/distinct_count(alias.field)`. This struct
+/// records which aliases are referenced by each so the builder skips the rest.
+///
+/// The cheap per-alias fields (`_count_{alias}`, `_first_{alias}`,
+/// `_last_{alias}`) are always built and are not gated by this analysis.
+///
+/// Correctness bias: over-inclusion is safe (builds something unused);
+/// under-inclusion drops a field a pipeline reads. The analysis is deliberately
+/// conservative — when in doubt, include.
+#[derive(Debug, Clone, Default)]
+pub struct SequenceMatchConfig {
+    /// Aliases read via positional index (`alias[i]`) or `collect(alias.field)`.
+    /// These require the full `_events_{alias}` array to be materialized.
+    pub aliases_needing_events: FxHashSet<String>,
+    /// Aliases read via `sum/avg/min/max/distinct_count(alias.field)`.
+    /// These require the per-field numeric/distinct aggregates.
+    pub aliases_needing_aggs: FxHashSet<String>,
+}
+
 /// Runtime operations that can be applied to a stream
 #[allow(dead_code)]
 pub enum RuntimeOp {
@@ -228,8 +258,13 @@ pub enum RuntimeOp {
     Print(PrintConfig),
     /// Log with level
     Log(LogConfig),
-    /// Sequence operation - index into sequence_tracker steps
-    Sequence,
+    /// Sequence operation - index into sequence_tracker steps.
+    ///
+    /// Carries a compile-time analysis of which Kleene aliases the downstream
+    /// pipeline actually references, so the per-match builder can skip the
+    /// expensive per-alias structures (`_events_{alias}` arrays, per-field
+    /// aggregates) that nothing reads. See [`SequenceMatchConfig`].
+    Sequence(SequenceMatchConfig),
     /// Pattern matching with lambda expression
     Pattern(PatternConfig),
     /// Process with expression: `.process(expr)` - evaluates for side effects (emit)
@@ -279,7 +314,7 @@ impl RuntimeOp {
             Self::EmitExpr(_) => "EmitExpr",
             Self::Print(_) => "Print",
             Self::Log(_) => "Log",
-            Self::Sequence => "Sequence",
+            Self::Sequence(_) => "Sequence",
             Self::Pattern(_) => "Pattern",
             Self::Process(_) => "Process",
             Self::To(_) => "Sink",

--- a/crates/varpulis-runtime/tests/sequence_lazy_build_tests.rs
+++ b/crates/varpulis-runtime/tests/sequence_lazy_build_tests.rs
@@ -1,0 +1,130 @@
+//! Tests for lazy per-alias structure building in the Sequence op.
+//!
+//! When a Kleene/sequence match completes, `pipeline.rs` used to build, for
+//! every alias, a `_events_{alias}` array (a deep clone of every captured
+//! event) plus per-field aggregates — O(events) per match, O(events²) over a
+//! Kleene run, which OOMs on long runs. A compile-time analysis
+//! (`engine::sequence_analysis`) now records which aliases the downstream
+//! pipeline actually reads via positional access / `collect(...)` / aggregate
+//! calls, and the builder skips the expensive structures for the rest. It also
+//! caps the materialized `_events_{alias}` array at `MAX_ARRAY_ELEMENTS`.
+//!
+//! Observation strategy: a stream whose only terminal op is `.to(<connector>)`
+//! (with no `.emit()`) forwards the *raw* `SequenceMatch` event — internal
+//! `_count_`/`_events_`/`_agg_` keys intact — to the output channel. The
+//! connector is intentionally unregistered: `.to()` warns at runtime and leaves
+//! the event untouched, which is exactly what we want to inspect. (`.emit(...)`
+//! would rebuild a fresh event containing only the emitted fields, hiding the
+//! internal keys.)
+#![allow(clippy::needless_raw_string_hashes)]
+
+use tokio::sync::mpsc;
+use varpulis_core::Value;
+use varpulis_parser::parse;
+use varpulis_runtime::engine::Engine;
+use varpulis_runtime::event::Event;
+
+/// Load `code`, feed `events` one at a time through the async engine, and
+/// return everything that reached the output channel.
+async fn run(code: &str, events: Vec<Event>) -> Vec<Event> {
+    let program = parse(code).expect("parse");
+    let (tx, mut rx) = mpsc::channel(16_384);
+    let mut engine = Engine::new(tx);
+    engine.load(&program).expect("load");
+    for e in events {
+        engine.process(e).await.expect("process");
+    }
+    let mut out = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        out.push(e);
+    }
+    out
+}
+
+fn news(id: i64) -> Event {
+    Event::new("News").with_field("id", id)
+}
+
+fn tick(price: f64) -> Event {
+    Event::new("Tick").with_field("price", price)
+}
+
+fn key_names(e: &Event) -> Vec<String> {
+    e.data.keys().map(|k| k.to_string()).collect()
+}
+
+/// Primary (fast): when nothing downstream indexes or collects the alias, the
+/// expensive `_events_{alias}` array must be skipped, while the cheap
+/// `_count_{alias}` scalar is still built.
+///
+/// Fail-before: with the build ungated (always runs), `_events_tick` is present
+/// and the `is_none()` assertion fails. Pass-after: it is absent.
+#[tokio::test]
+async fn lazy_skips_events_array_when_unreferenced() {
+    let code = r#"
+        stream S = News as news -> all Tick as tick .to(NullSink)
+    "#;
+    let out = run(code, vec![news(1), tick(100.0), tick(101.0), tick(102.0)]).await;
+    assert!(
+        !out.is_empty(),
+        "expected raw SequenceMatch events on the output channel"
+    );
+    for e in &out {
+        assert!(
+            e.get("_count_tick").is_some(),
+            "cheap _count_tick must always be built; keys={:?}",
+            key_names(e)
+        );
+        assert!(
+            e.get("_events_tick").is_none(),
+            "expensive _events_tick must be SKIPPED when unreferenced; keys={:?}",
+            key_names(e)
+        );
+    }
+}
+
+/// A downstream reference to the alias array (`tick[0]` in a where-clause) must
+/// still cause `_events_{alias}` to be built, with correct contents.
+///
+/// Fail-before: if the analysis fails to flag the reference (or the build is
+/// force-skipped), `_events_tick` is absent and the `panic!` in the `match`
+/// fires. Pass-after: it is present and correct.
+#[tokio::test]
+async fn referenced_alias_still_builds_events_array() {
+    let code = r#"
+        stream S = News as news -> all Tick as tick
+            .where(tick[0].price >= 0.0)
+            .to(NullSink)
+    "#;
+    let out = run(code, vec![news(1), tick(100.0), tick(101.0), tick(102.0)]).await;
+    assert!(!out.is_empty(), "expected SequenceMatch events");
+
+    // The last incremental match carries all three ticks.
+    let best = out
+        .iter()
+        .max_by_key(|e| e.get("_count_tick").and_then(Value::as_int).unwrap_or(0))
+        .expect("some output");
+
+    let arr = match best.get("_events_tick") {
+        Some(Value::Array(a)) => a,
+        other => panic!("_events_tick must be present as an Array when referenced, got {other:?}"),
+    };
+    assert_eq!(arr.len(), 3, "array should hold all 3 captured ticks");
+    match &arr[0] {
+        Value::Map(m) => assert_eq!(
+            m.get("price"),
+            Some(&Value::Float(100.0)),
+            "first captured tick price"
+        ),
+        other => panic!("expected Map element, got {other:?}"),
+    }
+    assert_eq!(best.get("_count_tick"), Some(&Value::Int(3)));
+}
+
+// NOTE on the array cap: the `_events_{alias}` array is truncated at
+// `MAX_ARRAY_ELEMENTS` (10_000). That cap cannot be exercised end-to-end
+// through VPL, because SASE bounds every Kleene closure at `MAX_KLEENE_EVENTS`
+// (20) to keep ZDD enumeration from blowing up — so no alias ever groups more
+// than ~20 events here. The truncation is a defensive backstop and is unit
+// tested directly against the extracted `build_events_array` helper in
+// `engine::pipeline::tests` (`build_events_array_truncates_at_cap`).


### PR DESCRIPTION
## Audit item: SequenceMatch O(n²)/OOM — investigated & scoped honestly

The audit flagged the SequenceMatch build as O(n²)/OOM: on every Kleene match it unconditionally built, **per alias**, a `_events_{alias}` array (deep-cloning every captured event's every field) plus per-field sum/avg/min/max/distinct aggregates — even when the downstream reads none of them.

**Investigation correction (important):** SASE bounds every Kleene closure at `MAX_KLEENE_EVENTS = 20` (to cap ZDD 2ⁿ enumeration), so `_events_{alias}` can't exceed ~20 elements via the VPL path — **the true OOM/O(n²) is not reachable end-to-end.** The real, reachable cost is the *unconditional* per-match deep-clone + aggregate scan on the Kleene hot path (one incremental match per event). This PR makes that work **lazy** — a hot-path optimization + defensive hardening, not a crash fix. Framing it accurately.

## Change
- New `SequenceMatchConfig { aliases_needing_events, aliases_needing_aggs }` on `RuntimeOp::Sequence`, populated at compile time by a new `sequence_analysis` module: an **exhaustive** walk of the downstream ops (no `_` match arms — a new `RuntimeOp`/`Expr` variant is a compile error, not a silent miss).
  - An alias needs `_events_` iff read via `alias[i]` or `collect(alias[.field])`; needs aggregates iff read via `sum|avg|min|max|distinct_count(alias.field)`. Verified against the evaluator's actual read paths (`LEN`/`count` → `_count_`, aggregates → `_agg_` scalars, bare `Ident(alias)` → neither). **Bias is to over-include** (build when unsure); under-including would drop a field a pipeline reads.
- Build `_count_`/`_first_`/`_last_` always (cheap); `_events_`/aggregates only for referenced aliases.
- `_events_` capped at `MAX_ARRAY_ELEMENTS` defensively (unit-tested; unreachable via VPL today, load-bearing if the Kleene bound is ever raised).
- Distinct now uses `HashSet<&Value>` (Value has consistent `Hash`+`Eq`) instead of a `format!("{v:?}")` String per value.

## Fail-before / pass-after (self-verified, not just the implementing agent's report)
| test | fail-before | pass-after |
|---|---|---|
| `lazy_skips_events_array_when_unreferenced` | gate → always-build: `_events_tick`/`_events_news` present ❌ | skipped ✅ |
| `referenced_alias_still_builds_events_array` | analysis under-includes → `.where(tick[0])` drops all events ❌ | resolves ✅ |
| `build_events_array_truncates_at_cap` | `.take(cap)` removed: 10005 vs 10000 ❌ | capped ✅ |

**Full `cargo test -p varpulis-runtime`: 2450 passed, 0 failed** (the whole sequence/kleene/sase suite is the correctness safety net for the analysis). Scoped `clippy -D warnings` + nightly-fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)