### PR TITLE
fix(connector-cdc): wire real rustls TLS so sslmode is honored, not silently ignored (audit HIGH, security)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2201,6 +2201,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
+ "der_derive",
+ "flagset",
  "pem-rfc7468 0.7.0",
  "zeroize",
 ]
@@ -2213,6 +2215,17 @@ checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "pem-rfc7468 1.0.0",
  "zeroize",
+]
+
+[[package]]
+name = "der_derive"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034092389675178f570469e6c3b0465d3d30b4505c294a6550db47f3c17ad18"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2594,7 +2607,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2655,7 +2668,7 @@ checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2724,6 +2737,12 @@ name = "fixedbitset"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
+name = "flagset"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ac824320a75a52197e8f2d787f6a38b6718bb6897a35142d749af3c0e8f4fe"
 
 [[package]]
 name = "flate2"
@@ -3444,7 +3463,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -3799,7 +3818,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4822,7 +4841,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.17",
  "http 1.4.0",
@@ -5863,7 +5882,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5900,9 +5919,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6546,7 +6565,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6559,7 +6578,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7657,7 +7676,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7814,6 +7833,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
+name = "tls_codec"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de2e01245e2bb89d6f05801c564fa27624dbd7b1846859876c7dad82e90bf6b"
+dependencies = [
+ "tls_codec_derive",
+ "zeroize",
+]
+
+[[package]]
+name = "tls_codec_derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2e76690929402faae40aebdda620a2c0e25dd6d3b9afe48867dfd95991f4bd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "tokio"
 version = "1.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7875,6 +7915,20 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami 2.1.1",
+]
+
+[[package]]
+name = "tokio-postgres-rustls"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c2ad44aa0ae96db89c4742212ed41645b2f597311ff6e1945542a4d9fadc2fb"
+dependencies = [
+ "rustls 0.23.37",
+ "sha2 0.11.0",
+ "tokio",
+ "tokio-postgres",
+ "tokio-rustls 0.26.4",
+ "x509-cert",
 ]
 
 [[package]]
@@ -8662,10 +8716,14 @@ name = "varpulis-connector-cdc"
 version = "0.10.0"
 dependencies = [
  "async-trait",
+ "rustls 0.23.37",
+ "rustls-native-certs 0.8.3",
+ "rustls-pemfile",
  "schemars 1.2.1",
  "serde",
  "tokio",
  "tokio-postgres",
+ "tokio-postgres-rustls",
  "tracing",
  "varpulis-connector-api",
  "varpulis-core",
@@ -9838,7 +9896,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10249,6 +10307,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "x509-cert"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1301e935010a701ae5f8655edc0ad17c44bad3ac5ce8c39185f75453b720ae94"
+dependencies = [
+ "const-oid 0.9.6",
+ "der 0.7.10",
+ "spki 0.7.3",
+ "tls_codec",
 ]
 
 [[package]]

--- a/crates/varpulis-connector-cdc/Cargo.toml
+++ b/crates/varpulis-connector-cdc/Cargo.toml
@@ -12,6 +12,10 @@ description = "PostgreSQL CDC (Change Data Capture) connector for Varpulis CEP e
 varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
 varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
+tokio-postgres-rustls = "0.14"
+rustls = { workspace = true }
+rustls-native-certs = "0.8"
+rustls-pemfile = "2"
 tokio = { workspace = true }
 serde = { workspace = true }
 schemars = { workspace = true }

--- a/crates/varpulis-connector-cdc/src/lib.rs
+++ b/crates/varpulis-connector-cdc/src/lib.rs
@@ -212,6 +212,301 @@ fn validate_slot_name(name: &str) -> Result<(), ConnectorError> {
     Ok(())
 }
 
+// =============================================================================
+// TLS support for PostgreSQL connections
+//
+// tokio-postgres only understands sslmode = disable | prefer | require and,
+// when handed `NoTls`, SILENTLY ignores any TLS intent (sslmode=prefer =>
+// cleartext; verify-ca/verify-full aren't even parseable). We therefore map the
+// full set of libpq sslmode values to an explicit (tokio-postgres sslmode, TLS
+// connector, certificate verifier) triple here, so replication traffic (row
+// data + credentials) is genuinely encrypted when the operator asks for it.
+//
+// SECURITY: the no-verify verifier below is reachable ONLY for
+// require/prefer/allow. verify-ca/verify-full always use the standard WebPki
+// verifier and reject an untrusted certificate.
+// =============================================================================
+
+/// Build the base libpq connection string WITHOUT an `sslmode=` fragment.
+///
+/// [`connect_pg`] appends the tokio-postgres-level sslmode that matches the TLS
+/// connector it chooses. Keeping sslmode out of the base string means the raw
+/// (and possibly richer, e.g. `verify-full`) user value is never handed to
+/// tokio-postgres's parser, which only accepts disable/prefer/require.
+fn base_conn_string(config: &PostgresCdcConfig) -> String {
+    format!(
+        "host={} port={} dbname={} user={} password={}",
+        config.host,
+        config.port,
+        config.dbname,
+        config.user,
+        config.password.expose(),
+    )
+}
+
+/// Server-certificate verifier that ACCEPTS ANY certificate without validation.
+///
+/// SECURITY: performs no chain, expiry, or hostname checks — it implements the
+/// libpq `require`/`prefer`/`allow` semantics of "encrypt the connection but do
+/// not authenticate the server". It is installed EXCLUSIVELY by
+/// [`build_tls_config_noverify`] and MUST NEVER be used for verify-ca /
+/// verify-full (those go through [`build_tls_config_verify`], which uses the
+/// standard `WebPkiServerVerifier`).
+#[derive(Debug)]
+struct NoCertVerifier;
+
+impl rustls::client::danger::ServerCertVerifier for NoCertVerifier {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp_response: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        rustls::crypto::ring::default_provider()
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+/// Read a PEM certificate chain from `path`.
+fn load_cert_chain(
+    path: &str,
+) -> Result<Vec<rustls::pki_types::CertificateDer<'static>>, ConnectorError> {
+    let data = std::fs::read(path).map_err(|e| {
+        ConnectorError::ConfigError(format!("cannot read certificate {path:?}: {e}"))
+    })?;
+    let certs = rustls_pemfile::certs(&mut std::io::BufReader::new(&data[..]))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| {
+            ConnectorError::ConfigError(format!("invalid PEM certificate {path:?}: {e}"))
+        })?;
+    if certs.is_empty() {
+        return Err(ConnectorError::ConfigError(format!(
+            "no certificates found in {path:?}"
+        )));
+    }
+    Ok(certs)
+}
+
+/// Read the first PEM private key from `path`.
+fn load_private_key(
+    path: &str,
+) -> Result<rustls::pki_types::PrivateKeyDer<'static>, ConnectorError> {
+    let data = std::fs::read(path).map_err(|e| {
+        ConnectorError::ConfigError(format!("cannot read private key {path:?}: {e}"))
+    })?;
+    rustls_pemfile::private_key(&mut std::io::BufReader::new(&data[..]))
+        .map_err(|e| ConnectorError::ConfigError(format!("invalid PEM private key {path:?}: {e}")))?
+        .ok_or_else(|| ConnectorError::ConfigError(format!("no private key found in {path:?}")))
+}
+
+/// Apply mTLS client authentication to a rustls builder in the `WantsClientCert`
+/// state — shared by the verify and no-verify code paths.
+///
+/// If BOTH `ssl_certificate_location` and `ssl_key_location` are set, the client
+/// cert/key are loaded and installed. If NEITHER is set, no client auth is used.
+/// If exactly one is set, that is a misconfiguration and a `ConfigError` is
+/// returned (fail closed rather than silently connect without the intended
+/// client identity).
+fn finish_client_auth(
+    builder: rustls::ConfigBuilder<rustls::ClientConfig, rustls::client::WantsClientCert>,
+    config: &PostgresCdcConfig,
+) -> Result<rustls::ClientConfig, ConnectorError> {
+    match (
+        config.ssl_certificate_location.as_deref(),
+        config.ssl_key_location.as_deref(),
+    ) {
+        (Some(cert_path), Some(key_path)) => {
+            let certs = load_cert_chain(cert_path)?;
+            let key = load_private_key(key_path)?;
+            builder.with_client_auth_cert(certs, key).map_err(|e| {
+                ConnectorError::ConfigError(format!("invalid mTLS client certificate/key: {e}"))
+            })
+        }
+        (None, None) => Ok(builder.with_no_client_auth()),
+        (Some(_), None) => Err(ConnectorError::ConfigError(
+            "mTLS misconfigured: ssl_certificate_location is set but ssl_key_location is not"
+                .to_string(),
+        )),
+        (None, Some(_)) => Err(ConnectorError::ConfigError(
+            "mTLS misconfigured: ssl_key_location is set but ssl_certificate_location is not"
+                .to_string(),
+        )),
+    }
+}
+
+/// Build a rustls `ClientConfig` that ENCRYPTS but does NOT verify the server
+/// certificate — the libpq `require`/`prefer`/`allow` semantics.
+///
+/// SECURITY: installs [`NoCertVerifier`]. Only [`connect_pg`]'s
+/// require/prefer/allow arm calls this.
+fn build_tls_config_noverify(
+    config: &PostgresCdcConfig,
+) -> Result<rustls::ClientConfig, ConnectorError> {
+    // Mirror the MQTT connector: ensure a process-default crypto provider is
+    // installed before constructing any ClientConfig (idempotent; ignore the
+    // "already installed" error).
+    let _ = rustls::crypto::ring::default_provider().install_default();
+    let builder = rustls::ClientConfig::builder()
+        .dangerous()
+        .with_custom_certificate_verifier(std::sync::Arc::new(NoCertVerifier));
+    finish_client_auth(builder, config)
+}
+
+/// Build a rustls `ClientConfig` that VERIFIES the server certificate chain and
+/// hostname via rustls's default `WebPkiServerVerifier` — the libpq
+/// `verify-ca`/`verify-full` semantics.
+///
+/// Roots come from `ssl_ca_location` (a PEM bundle) when set, otherwise the OS
+/// trust store. NEVER installs [`NoCertVerifier`].
+fn build_tls_config_verify(
+    config: &PostgresCdcConfig,
+) -> Result<rustls::ClientConfig, ConnectorError> {
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let mut roots = rustls::RootCertStore::empty();
+    if let Some(ca_path) = config.ssl_ca_location.as_deref() {
+        for cert in load_cert_chain(ca_path)? {
+            roots.add(cert).map_err(|e| {
+                ConnectorError::ConfigError(format!("invalid CA certificate {ca_path:?}: {e}"))
+            })?;
+        }
+    } else {
+        let native = rustls_native_certs::load_native_certs();
+        for cert in native.certs {
+            // Skip individual malformed system certs; a single bad root should
+            // not abort the connection as long as some roots load.
+            let _ = roots.add(cert);
+        }
+        if roots.is_empty() {
+            let detail = match native.errors.first() {
+                Some(e) => e.to_string(),
+                None => "system trust store is empty".to_string(),
+            };
+            return Err(ConnectorError::ConfigError(format!(
+                "sslmode={} requires trusted CA roots but none were loaded from the system \
+                 trust store ({detail}); set ssl_ca_location to a PEM CA bundle",
+                config.sslmode
+            )));
+        }
+    }
+
+    let builder = rustls::ClientConfig::builder().with_root_certificates(roots);
+    finish_client_auth(builder, config)
+}
+
+/// Open a cleartext (`NoTls`) connection and spawn its background driver task.
+async fn connect_notls(conn_string: &str) -> Result<tokio_postgres::Client, ConnectorError> {
+    let (client, connection) = tokio_postgres::connect(conn_string, tokio_postgres::NoTls)
+        .await
+        .map_err(|e| ConnectorError::ConnectionFailed(format!("PostgreSQL: {e}")))?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("PostgreSQL connection error: {e}");
+        }
+    });
+    Ok(client)
+}
+
+/// Open a rustls TLS connection with `tls_config` and spawn its background
+/// driver task. Split from [`connect_notls`] because tokio-postgres returns a
+/// differently-typed `Connection` per TLS connector, so each driver future must
+/// be spawned in its own monomorphized arm.
+async fn connect_rustls(
+    conn_string: &str,
+    tls_config: rustls::ClientConfig,
+) -> Result<tokio_postgres::Client, ConnectorError> {
+    let tls = tokio_postgres_rustls::MakeRustlsConnect::new(tls_config);
+    let (client, connection) = tokio_postgres::connect(conn_string, tls)
+        .await
+        .map_err(|e| ConnectorError::ConnectionFailed(format!("PostgreSQL: {e}")))?;
+    tokio::spawn(async move {
+        if let Err(e) = connection.await {
+            tracing::error!("PostgreSQL connection error: {e}");
+        }
+    });
+    Ok(client)
+}
+
+/// Connect to PostgreSQL, honoring `config.sslmode` with a real rustls TLS
+/// implementation.
+///
+/// `base_conn_string` MUST NOT contain an `sslmode=` fragment (see
+/// [`base_conn_string`]); this function appends the tokio-postgres-level sslmode
+/// (`disable` or `require`) that matches the connector it selects.
+///
+/// SECURITY — sslmode -> (connector, server-cert verification):
+/// - `disable`                 -> `NoTls` (cleartext)
+/// - `require`                 -> rustls, NO verification (encrypt only); no fallback
+/// - `prefer` / `allow`        -> rustls, NO verification; fall back to cleartext on failure
+/// - `verify-ca` / `verify-full` -> rustls, WebPki verification of chain + hostname
+async fn connect_pg(
+    base_conn_string: &str,
+    config: &PostgresCdcConfig,
+) -> Result<tokio_postgres::Client, ConnectorError> {
+    let mode = config.sslmode.trim().to_ascii_lowercase();
+    match mode.as_str() {
+        "disable" => connect_notls(&format!("{base_conn_string} sslmode=disable")).await,
+        "require" | "prefer" | "allow" => {
+            // Encrypt but do NOT authenticate the server (libpq require/prefer).
+            let tls_config = build_tls_config_noverify(config)?;
+            // Force tokio-postgres to actually perform TLS: sslmode=require makes
+            // it send the SSLRequest and error if the server refuses SSL, so the
+            // prefer/allow cleartext fallback is driven explicitly here rather
+            // than by tokio-postgres silently downgrading.
+            let tls_conn_string = format!("{base_conn_string} sslmode=require");
+            match connect_rustls(&tls_conn_string, tls_config).await {
+                Ok(client) => Ok(client),
+                Err(e) => {
+                    if mode == "prefer" || mode == "allow" {
+                        tracing::warn!(
+                            "TLS connection failed for sslmode={mode}; falling back to \
+                             cleartext (libpq {mode} semantics): {e}"
+                        );
+                        connect_notls(&format!("{base_conn_string} sslmode=disable")).await
+                    } else {
+                        // require: never downgrade to cleartext.
+                        Err(e)
+                    }
+                }
+            }
+        }
+        "verify-ca" | "verify-full" => {
+            // Encrypt AND verify the certificate chain + hostname.
+            let tls_config = build_tls_config_verify(config)?;
+            connect_rustls(&format!("{base_conn_string} sslmode=require"), tls_config).await
+        }
+        other => Err(ConnectorError::ConfigError(format!(
+            "unsupported sslmode {other:?}: expected one of disable, allow, prefer, \
+             require, verify-ca, verify-full"
+        ))),
+    }
+}
+
 #[async_trait]
 impl SourceConnector for PostgresCdcSource {
     fn name(&self) -> &str {
@@ -225,34 +520,20 @@ impl SourceConnector for PostgresCdcSource {
         // it is interpolated into replication SQL with no parameter binding.
         validate_slot_name(&self.config.slot_name)?;
 
-        use tokio_postgres::NoTls;
         use tracing::{error, info, warn};
 
         self.running.store(true, Ordering::SeqCst);
 
-        let conn_string = format!(
-            "host={} port={} dbname={} user={} password={} sslmode={}",
-            self.config.host,
-            self.config.port,
-            self.config.dbname,
-            self.config.user,
-            self.config.password.expose(),
-            self.config.sslmode
-        );
+        // Base connection string WITHOUT sslmode: connect_pg appends the
+        // tokio-postgres-level sslmode (disable/require) that matches the TLS
+        // connector it selects for self.config.sslmode. See connect_pg for the
+        // full sslmode -> (connector, verifier) mapping.
+        let conn_string = base_conn_string(&self.config);
 
-        // TODO: For TLS support, add tokio-postgres-rustls dependency.
-        // Currently sslmode is passed in connection string but NoTls is used.
-        // sslmode=disable works; other modes require a TLS implementation.
-        let (client, connection) = tokio_postgres::connect(&conn_string, NoTls)
-            .await
-            .map_err(|e| ConnectorError::ConnectionFailed(format!("PostgreSQL: {}", e)))?;
-
-        // Spawn the connection task
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                error!("PostgreSQL connection error: {}", e);
-            }
-        });
+        // Connect honoring sslmode with a real rustls TLS implementation. Unlike
+        // the previous NoTls-only path, sslmode=require/verify-* now genuinely
+        // encrypt (and, for verify-*, authenticate) the replication stream.
+        let client = connect_pg(&conn_string, &self.config).await?;
 
         let slot_name = self.config.slot_name.clone();
         let publication = self.config.publication.clone();
@@ -867,5 +1148,134 @@ mod tests {
             err.to_string().contains("invalid replication slot name"),
             "must be rejected by slot validation, not a connection attempt: {err}"
         );
+    }
+}
+
+// =============================================================================
+// TLS integration tests
+//
+// These exercise connect_pg against a REAL TLS-enabled PostgreSQL (a container).
+// They skip gracefully (eprintln + return) when no such server is reachable, so
+// CI without one stays green — mirroring the MQTT real-broker test. Bring up the
+// server with the recipe in the connector's test docs and point the tests at it
+// via VARPULIS_TLS_PG_PORT / VARPULIS_TLS_PG_HOST / VARPULIS_TLS_PG_CA.
+// =============================================================================
+
+#[cfg(test)]
+mod tls_integration {
+    use super::*;
+
+    /// Resolve the TLS PostgreSQL test target `(host, port)` and confirm the
+    /// port is open, else return `None` so the caller skips. Host defaults to
+    /// `localhost` (the server cert's SAN); port to 5433. Both are overridable
+    /// via env so the same tests can target any TLS Postgres.
+    fn tls_pg_target() -> Option<(String, u16)> {
+        use std::net::{TcpStream, ToSocketAddrs};
+        let host =
+            std::env::var("VARPULIS_TLS_PG_HOST").unwrap_or_else(|_| "localhost".to_string());
+        let port: u16 = std::env::var("VARPULIS_TLS_PG_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(5433);
+        let reachable = (host.as_str(), port)
+            .to_socket_addrs()
+            .ok()
+            .and_then(|mut addrs| addrs.next())
+            .and_then(|addr| {
+                TcpStream::connect_timeout(&addr, std::time::Duration::from_millis(500)).ok()
+            })
+            .is_some();
+        reachable.then_some((host, port))
+    }
+
+    fn target_config(host: &str, port: u16, sslmode: &str) -> PostgresCdcConfig {
+        PostgresCdcConfig::new(host, "postgres")
+            .with_port(port)
+            .with_credentials("postgres", "")
+            .with_sslmode(sslmode)
+    }
+
+    /// PRIMARY GATE — `sslmode=require` genuinely uses TLS.
+    ///
+    /// Against a PostgreSQL that REQUIRES SSL (its `pg_hba.conf` rejects non-SSL
+    /// connections), an `sslmode=require` connect must SUCCEED, which is only
+    /// possible if real TLS is negotiated.
+    ///
+    /// Fail-before: force the require arm to `connect_notls` -> the SSL-only
+    /// server rejects the plaintext connection -> `connect_pg` errors ->
+    /// `expect` panics (RED). Pass-after: rustls TLS -> connects and a trivial
+    /// query returns 1 (GREEN).
+    #[tokio::test]
+    async fn sslmode_require_negotiates_real_tls() {
+        let Some((host, port)) = tls_pg_target() else {
+            eprintln!("[skip] TLS PostgreSQL not reachable (set VARPULIS_TLS_PG_PORT)");
+            return;
+        };
+        let config = target_config(&host, port, "require");
+        let client = connect_pg(&base_conn_string(&config), &config)
+            .await
+            .expect("sslmode=require must negotiate TLS against the SSL-requiring server");
+        let rows = client
+            .query("SELECT 1::int AS one", &[])
+            .await
+            .expect("query over the TLS connection");
+        let one: i32 = rows[0].get("one");
+        assert_eq!(one, 1, "the TLS connection must be usable");
+    }
+
+    /// GUARD — `sslmode=verify-full` cannot silently skip verification.
+    ///
+    /// With NO `ssl_ca_location` (system roots only), verify-full against a
+    /// SELF-SIGNED server cert must FAIL with a verification error, proving the
+    /// verify path uses the real WebPki verifier.
+    ///
+    /// Fail-before: point the verify arm at `build_tls_config_noverify` -> the
+    /// self-signed cert is wrongly accepted -> `connect_pg` returns Ok ->
+    /// `expect_err` panics (RED). Pass-after: WebPki rejects the untrusted
+    /// self-signed cert -> `connect_pg` errors (GREEN).
+    #[tokio::test]
+    async fn sslmode_verify_full_rejects_untrusted_self_signed() {
+        let Some((host, port)) = tls_pg_target() else {
+            eprintln!("[skip] TLS PostgreSQL not reachable (set VARPULIS_TLS_PG_PORT)");
+            return;
+        };
+        let config = target_config(&host, port, "verify-full");
+        let err = connect_pg(&base_conn_string(&config), &config)
+            .await
+            .expect_err("verify-full with system roots must reject the self-signed server cert");
+        let msg = err.to_string().to_lowercase();
+        assert!(
+            msg.contains("certificate")
+                || msg.contains("verif")
+                || msg.contains("unknown")
+                || msg.contains("self-signed")
+                || msg.contains("tls"),
+            "expected a certificate-verification failure, got: {err}"
+        );
+    }
+
+    /// NICE-TO-HAVE — verify-full succeeds when the self-signed cert is pinned as
+    /// the CA and the host matches the cert SAN. Requires VARPULIS_TLS_PG_CA to
+    /// point at the server cert PEM; skips otherwise.
+    #[tokio::test]
+    async fn sslmode_verify_full_succeeds_with_pinned_ca() {
+        let Some((host, port)) = tls_pg_target() else {
+            eprintln!("[skip] TLS PostgreSQL not reachable");
+            return;
+        };
+        let Ok(ca_path) = std::env::var("VARPULIS_TLS_PG_CA") else {
+            eprintln!("[skip] VARPULIS_TLS_PG_CA not set (path to server self-signed cert PEM)");
+            return;
+        };
+        let config = target_config(&host, port, "verify-full").with_ca_cert(&ca_path);
+        let client = connect_pg(&base_conn_string(&config), &config)
+            .await
+            .expect("verify-full with the pinned CA and SAN-matching host must connect");
+        let rows = client
+            .query("SELECT 1::int AS one", &[])
+            .await
+            .expect("query over the verified TLS connection");
+        let one: i32 = rows[0].get("one");
+        assert_eq!(one, 1);
     }
 }


### PR DESCRIPTION
## Audit finding: CDC hardcodes `NoTls` → `sslmode` silently ignored (cleartext replication)

The connector built a Postgres connection string with `sslmode={}` from config but connected with hardcoded `NoTls`, so the setting was ignored.

**Sharpened by investigation (tokio-postgres 0.7 internals):** with `NoTls`, `sslmode=require` actually *errors* and `verify-ca`/`verify-full`/`allow` don't even parse — so the genuine **silent-cleartext** hole was `sslmode=prefer` (the **config default**) and `allow`, which return a plaintext stream whenever TLS is unavailable. A user trusting the default believed replication traffic (row data + credentials) was encrypted; it wasn't. This fix makes every mode behave correctly *and* closes that default-cleartext path.

## Fix — `connect_pg` selects a connector per sslmode (rustls 0.23, ring provider, mirroring the MQTT connector)

| `sslmode` | connector | server-cert verification | cleartext fallback |
|---|---|---|---|
| `disable` | `NoTls` | none | n/a |
| `require` | rustls | **none** (encrypt-only) | **no** (errors if server refuses SSL) |
| `prefer` / `allow` | rustls | none (encrypt-only) | yes → NoTls (libpq semantics) |
| `verify-ca` / `verify-full` | rustls | **`WebPkiServerVerifier`** (chain + hostname) | no |
| other | — | `ConfigError` | — |

- mTLS via `ssl_certificate_location` + `ssl_key_location` for any TLS mode.
- The dangerous no-cert verifier is constructed in **one** function, reachable **only** from the require/prefer/allow arm — `verify-*` can never use it.
- `verify-ca` here also checks hostname (stricter than libpq's chain-only verify-ca — safer, never weaker; flagged in the commit).

## Gated against a real TLS-requiring Postgres 16 container (broker-skip-graceful)

| test | fail-before | pass-after |
|---|---|---|
| `sslmode_require_negotiates_real_tls` | require arm forced to `NoTls` → SSL-only server rejects ❌ | connects over TLS ✅ |
| `sslmode_verify_full_rejects_untrusted_self_signed` | verify arm → no-verify builder: cert wrongly accepted, `expect_err` gets `Ok(Client)` ❌ | untrusted cert refused ✅ |
| `sslmode_verify_full_succeeds_with_pinned_ca` | — | verify-full + pinned CA connects ✅ |

**Both security fail-befores self-verified against the live container** (not just the implementing agent's report). 21 CDC tests pass (existing + 3 TLS); scoped `clippy -D warnings` + nightly-fmt clean; `cargo deny` advisories/bans/licenses/sources ok. New deps: `tokio-postgres-rustls 0.14`, `rustls-native-certs 0.8`, `rustls-pemfile 2` (rustls stays 0.23.37 — no new major).

> Follow-up (pre-existing, out of scope): the conn string is still space-separated `key=value` interpolation; a special char in a credential could misparse — switching to `tokio_postgres::Config` builder would harden it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)