### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,83 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-17
+
+Outcome of a full 11-scope codebase audit plus the distributed exactly-once
+("Flink-parity") work. This release closes every audit critical and the
+high/medium-severity findings — silent event drops, unbounded-memory growth,
+cleartext credentials, and cluster control-plane gaps — and adds end-to-end
+exactly-once checkpointing. (Documents everything since v0.10.0, which shipped
+without a changelog entry.) No VPL language changes; a few connector/sink
+behaviours changed — see **Changed**.
+
+### Added
+
+- **Distributed exactly-once checkpointing** — a two-phase-commit checkpoint
+  barrier in the engine, a coordinator orchestrator, worker-side barrier handler,
+  Raft integration, and a NATS checkpoint protocol, with checkpoint-based pipeline
+  migration and recovery-commit of restored 2PC state.
+- **Postgres CDC over TLS** — the CDC connector now honours `sslmode`
+  (`require`/`verify-ca`/`verify-full`) via rustls, with CA pinning
+  (`ssl_ca_location`) and optional mTLS (`ssl_certificate_location` /
+  `ssl_key_location`).
+- **Dynamic topic routing on Redis** — `.to(expr)` publishes to the evaluated
+  channel (pub/sub) or stream key (streams), matching Kafka/MQTT/NATS.
+- **Source auto-reconnect** — MQTT, Redis pub/sub, and Pulsar sources reconnect
+  and re-subscribe after the broker drops the connection instead of going
+  silently deaf.
+- **Kafka dead-letter for undecodable records** — malformed source records are
+  counted, logged, and (when a DLQ is configured) dead-lettered instead of being
+  silently skipped.
+
+### Changed
+
+- **Dynamic `.to(topic)` on a sink that cannot route by topic now returns an
+  explicit error** instead of silently delivering to the connector's fixed
+  destination — the caller's routing intent is no longer dropped without a
+  signal. Sinks that can route by topic (Kafka/MQTT/NATS/Redis/syslog/slack) are
+  unaffected.
+- **SequenceMatch build is now lazy** — per-alias `_events`/aggregate structures
+  are materialised only when a downstream operator references them.
+- Toolchain moved to Rust 1.95; `wasm32-unknown-unknown` target added.
+
+### Fixed
+
+- **Exactly-once correctness** — checkpoint windowed-aggregate state (C1); drain
+  in-flight events before the snapshot (C3); commit source offsets inside the sink
+  transaction (C4); checkpoint-barrier failures are now fatal rather than
+  logged-and-ignored.
+- **Event-time watermarks** — observed on all four dispatch paths (C2a); time
+  windows close on watermark advance, not on event arrival (C2b); empty partition
+  windows are evicted on advance.
+- **Cluster control plane** — dead workers are detected via a replicated heartbeat
+  sequence (C5); deploy/teardown/inject/migrate and auto-failover migration are
+  routed over NATS when configured (C6); `/api/v1/cluster/raft` now requires auth.
+- **Bounded memory** — `TrendAggregate` accumulation is bounded to the WITHIN
+  window; SASE evicts empty partitions during cleanup; idle partition windows are
+  evicted; event-file reads are capped; `S3StateStore` no longer panics on
+  `block_on` inside the runtime; orphaned `.tmp` files are swept on
+  `FileStore::open`.
+- **Connectors** — `HttpSink` returns `Err` on a non-2xx response instead of
+  silently dropping events; hot reload preserves Sequence/Join routing.
+- **Parser/evaluator safety** — checked integer arithmetic, saturating timestamp
+  parsing, order-independent map `Hash`/`Eq`; run-grouped dispatch preserves
+  cross-stream FIFO interleave.
+- **Kafka hot path** — allocation-lean rewrite: 88.5k → 136k+ eps on the Arroyo
+  filter benchmark.
+
+### Security
+
+- **CDC replication slot name** is validated to close a SQL-injection hole.
+- **CDC replication is no longer cleartext** — `sslmode` is honoured (was silently
+  ignored under a hardcoded `NoTls`).
+- **Credentials are redacted from `Debug`** across Kafka, Redis, HTTP, Pulsar, the
+  generic `ConnectorConfig`, and `ConnectorProfile` — passwords, tokens, and API
+  keys no longer leak into logs, error chains, or panic messages.
+- **Internal API-key checks are constant-time**; the standalone server caps
+  concurrent WebSocket connections; the public pipeline-graph endpoints bound VPL
+  parse cost so they cannot be used for CPU-exhaustion DoS.
+
 ## [0.9.0] - 2026-03-26
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8575,7 +8575,7 @@ checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "varpulis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "varpulis-core",
  "varpulis-runtime",
@@ -8583,7 +8583,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-actors"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "serde",
@@ -8596,7 +8596,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-cli"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "argon2",
@@ -8658,7 +8658,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-cluster"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -8694,7 +8694,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-api"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8713,7 +8713,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-cdc"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "rustls 0.23.37",
@@ -8731,7 +8731,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-database"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "inventory",
@@ -8747,7 +8747,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-elasticsearch"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8764,7 +8764,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-http"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -8783,7 +8783,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-kafka"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -8802,7 +8802,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-kinesis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8820,7 +8820,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-mqtt"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "indexmap 2.13.1",
@@ -8839,7 +8839,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-nats"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -8858,7 +8858,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-pulsar"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -8875,7 +8875,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-redis"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "futures-util",
@@ -8892,7 +8892,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-s3"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -8908,7 +8908,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-slack"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8923,7 +8923,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-splunk"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -8939,7 +8939,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connector-syslog"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8952,7 +8952,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-connectors"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -8989,7 +8989,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-core"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "indexmap 2.13.1",
@@ -9004,7 +9004,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-datagen"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "rand 0.10.0",
@@ -9014,7 +9014,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-db"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "serde",
@@ -9027,7 +9027,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-dead-letter"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "serde",
@@ -9038,7 +9038,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-engine-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "getrandom 0.4.2",
  "serde",
@@ -9052,7 +9052,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-enrichment"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "async-trait",
  "redis",
@@ -9067,7 +9067,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-hamlet"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "proptest",
  "rustc-hash",
@@ -9078,7 +9078,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-lsp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "dashmap 6.1.0",
  "tokio",
@@ -9091,7 +9091,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-mcp"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -9113,7 +9113,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-parser"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "insta",
  "logos",
@@ -9128,7 +9128,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-pst"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "hashlink 0.11.0",
  "proptest",
@@ -9138,7 +9138,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-runtime"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -9196,7 +9196,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-sase"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "iai-callgrind",
@@ -9207,14 +9207,14 @@ dependencies = [
 
 [[package]]
 name = "varpulis-simd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "varpulis-core",
 ]
 
 [[package]]
 name = "varpulis-wasm"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -9228,7 +9228,7 @@ dependencies = [
 
 [[package]]
 name = "varpulis-zdd"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "criterion",
  "rustc-hash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.10.0"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.93"
 authors = ["Varpulis Contributors"]
@@ -111,7 +111,7 @@ rustls = { version = "0.23", default-features = false, features = ["ring", "std"
 futures-util = "0.3"
 
 # Actor framework
-varpulis-actors = { version = "0.10.0", path = "crates/varpulis-actors" }
+varpulis-actors = { version = "0.11.0", path = "crates/varpulis-actors" }
 
 # OAuth & JWT
 jsonwebtoken = { version = "10", features = ["rust_crypto"] }

--- a/crates/varpulis-cli/Cargo.toml
+++ b/crates/varpulis-cli/Cargo.toml
@@ -19,9 +19,9 @@ name = "varpulis"
 path = "src/main.rs"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
-varpulis-runtime = { version = "0.10.0", path = "../varpulis-runtime", features = ["mqtt", "interactive"] }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
+varpulis-runtime = { version = "0.11.0", path = "../varpulis-runtime", features = ["mqtt", "interactive"] }
 tokio = { workspace = true }
 clap = { workspace = true }
 anyhow = { workspace = true }
@@ -47,8 +47,8 @@ thiserror = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
 reqwest = { workspace = true }
 async-trait = "0.1"
-varpulis-cluster = { version = "0.10.0", path = "../varpulis-cluster" }
-varpulis-datagen = { version = "0.10.0", path = "../varpulis-datagen" }
+varpulis-cluster = { version = "0.11.0", path = "../varpulis-cluster" }
+varpulis-datagen = { version = "0.11.0", path = "../varpulis-datagen" }
 jsonwebtoken = { workspace = true }
 urlencoding = "2"
 bytes = "1"
@@ -60,8 +60,8 @@ getrandom = "0.4"
 indicatif = "0.17"
 owo-colors = "4"
 comfy-table = "7"
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-connectors = { version = "0.10.0", path = "../varpulis-connectors" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-connectors = { version = "0.11.0", path = "../varpulis-connectors" }
 notify = "7"
 
 # REPL (optional, behind "repl" feature)
@@ -75,7 +75,7 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 openidconnect = { version = "4", optional = true }
 
 # SaaS layer (optional, behind "saas" feature)
-varpulis-db = { version = "0.10.0", path = "../varpulis-db", optional = true }
+varpulis-db = { version = "0.11.0", path = "../varpulis-db", optional = true }
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1-rustls-tls", "builder"], optional = true }
 
 # OpenTelemetry (optional, behind "otel" feature)

--- a/crates/varpulis-cluster/Cargo.toml
+++ b/crates/varpulis-cluster/Cargo.toml
@@ -9,9 +9,9 @@ documentation.workspace = true
 description = "Distributed execution cluster for Varpulis streaming analytics"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-runtime = { version = "0.10.0", path = "../varpulis-runtime", features = ["mqtt"] }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-runtime = { version = "0.11.0", path = "../varpulis-runtime", features = ["mqtt"] }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/varpulis-connector-api/Cargo.toml
+++ b/crates/varpulis-connector-api/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 description = "Shared traits and types for Varpulis connector crates"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 tokio = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-cdc/Cargo.toml
+++ b/crates/varpulis-connector-cdc/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "PostgreSQL CDC (Change Data Capture) connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 tokio-postgres = { version = "0.7", features = ["with-chrono-0_4", "with-serde_json-1"] }
 tokio-postgres-rustls = "0.14"
 rustls = { workspace = true }

--- a/crates/varpulis-connector-database/Cargo.toml
+++ b/crates/varpulis-connector-database/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Database connector (PostgreSQL, MySQL, SQLite) for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 sqlx = { version = "0.8", features = ["runtime-tokio", "any", "postgres", "mysql", "sqlite"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-elasticsearch/Cargo.toml
+++ b/crates/varpulis-connector-elasticsearch/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Elasticsearch connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 elasticsearch = "9.1.0-alpha.1"
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-http/Cargo.toml
+++ b/crates/varpulis-connector-http/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "HTTP connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 reqwest = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/crates/varpulis-connector-kafka/Cargo.toml
+++ b/crates/varpulis-connector-kafka/Cargo.toml
@@ -9,9 +9,9 @@ documentation.workspace = true
 description = "Kafka connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-dead-letter = { version = "0.10.0", path = "../varpulis-dead-letter" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-dead-letter = { version = "0.11.0", path = "../varpulis-dead-letter" }
 rdkafka = { version = "0.39", features = ["cmake-build", "ssl-vendored"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-kinesis/Cargo.toml
+++ b/crates/varpulis-connector-kinesis/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "AWS Kinesis connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 aws-config = "1.8"
 aws-sdk-kinesis = "1.101"
 tokio = { workspace = true }

--- a/crates/varpulis-connector-mqtt/Cargo.toml
+++ b/crates/varpulis-connector-mqtt/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "MQTT connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 rumqttc = { package = "rumqttc-v4-next", version = "0.28" }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-nats/Cargo.toml
+++ b/crates/varpulis-connector-nats/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "NATS connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 async-nats = "0.46"
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-pulsar/Cargo.toml
+++ b/crates/varpulis-connector-pulsar/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Apache Pulsar connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 pulsar = { version = "6", default-features = false, features = ["tokio-rustls-runtime-ring"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-redis/Cargo.toml
+++ b/crates/varpulis-connector-redis/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Redis connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 redis = { version = "1", features = ["tokio-comp", "connection-manager"] }
 tokio = { workspace = true }
 serde = { workspace = true }

--- a/crates/varpulis-connector-s3/Cargo.toml
+++ b/crates/varpulis-connector-s3/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "AWS S3 connector for Varpulis CEP engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 aws-config = "1.8"
 aws-sdk-s3 = "1.124"
 tokio = { workspace = true }

--- a/crates/varpulis-connector-slack/Cargo.toml
+++ b/crates/varpulis-connector-slack/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Slack webhook connector for Varpulis kill chain detection engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 reqwest = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/varpulis-connector-splunk/Cargo.toml
+++ b/crates/varpulis-connector-splunk/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Splunk HEC input connector for Varpulis kill chain detection engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 axum = { workspace = true }
 tokio = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/varpulis-connector-syslog/Cargo.toml
+++ b/crates/varpulis-connector-syslog/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "Syslog CEF/LEEF connector for Varpulis kill chain detection engine"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 tokio = { workspace = true }
 tracing = { workspace = true }
 inventory = { workspace = true }

--- a/crates/varpulis-connectors/Cargo.toml
+++ b/crates/varpulis-connectors/Cargo.toml
@@ -9,22 +9,22 @@ documentation.workspace = true
 description = "Connector implementations for Varpulis (MQTT, Kafka, NATS, HTTP, etc.)"
 
 [dependencies]
-varpulis-connector-api = { version = "0.10.0", path = "../varpulis-connector-api" }
-varpulis-connector-mqtt = { version = "0.10.0", path = "../varpulis-connector-mqtt", optional = true }
-varpulis-connector-kafka = { version = "0.10.0", path = "../varpulis-connector-kafka", optional = true }
-varpulis-connector-nats = { version = "0.10.0", path = "../varpulis-connector-nats", optional = true }
-varpulis-connector-redis = { version = "0.10.0", path = "../varpulis-connector-redis", optional = true }
-varpulis-connector-elasticsearch = { version = "0.10.0", path = "../varpulis-connector-elasticsearch", optional = true }
-varpulis-connector-pulsar = { version = "0.10.0", path = "../varpulis-connector-pulsar", optional = true }
-varpulis-connector-kinesis = { version = "0.10.0", path = "../varpulis-connector-kinesis", optional = true }
-varpulis-connector-s3 = { version = "0.10.0", path = "../varpulis-connector-s3", optional = true }
-varpulis-connector-database = { version = "0.10.0", path = "../varpulis-connector-database", optional = true }
-varpulis-connector-http = { version = "0.10.0", path = "../varpulis-connector-http" }
-varpulis-connector-slack = { version = "0.10.0", path = "../varpulis-connector-slack", optional = true }
-varpulis-connector-splunk = { version = "0.10.0", path = "../varpulis-connector-splunk", optional = true }
-varpulis-connector-syslog = { version = "0.10.0", path = "../varpulis-connector-syslog", optional = true }
-varpulis-connector-cdc = { version = "0.10.0", path = "../varpulis-connector-cdc", optional = true }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-connector-api = { version = "0.11.0", path = "../varpulis-connector-api" }
+varpulis-connector-mqtt = { version = "0.11.0", path = "../varpulis-connector-mqtt", optional = true }
+varpulis-connector-kafka = { version = "0.11.0", path = "../varpulis-connector-kafka", optional = true }
+varpulis-connector-nats = { version = "0.11.0", path = "../varpulis-connector-nats", optional = true }
+varpulis-connector-redis = { version = "0.11.0", path = "../varpulis-connector-redis", optional = true }
+varpulis-connector-elasticsearch = { version = "0.11.0", path = "../varpulis-connector-elasticsearch", optional = true }
+varpulis-connector-pulsar = { version = "0.11.0", path = "../varpulis-connector-pulsar", optional = true }
+varpulis-connector-kinesis = { version = "0.11.0", path = "../varpulis-connector-kinesis", optional = true }
+varpulis-connector-s3 = { version = "0.11.0", path = "../varpulis-connector-s3", optional = true }
+varpulis-connector-database = { version = "0.11.0", path = "../varpulis-connector-database", optional = true }
+varpulis-connector-http = { version = "0.11.0", path = "../varpulis-connector-http" }
+varpulis-connector-slack = { version = "0.11.0", path = "../varpulis-connector-slack", optional = true }
+varpulis-connector-splunk = { version = "0.11.0", path = "../varpulis-connector-splunk", optional = true }
+varpulis-connector-syslog = { version = "0.11.0", path = "../varpulis-connector-syslog", optional = true }
+varpulis-connector-cdc = { version = "0.11.0", path = "../varpulis-connector-cdc", optional = true }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/varpulis-dead-letter/Cargo.toml
+++ b/crates/varpulis-dead-letter/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 description = "Dead letter queue for events that fail sink delivery"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 chrono = { workspace = true }

--- a/crates/varpulis-engine-wasm/Cargo.toml
+++ b/crates/varpulis-engine-wasm/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["wasm", "data-structures"]
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
-varpulis-runtime = { version = "0.10.0", path = "../varpulis-runtime", default-features = false, features = ["wasm"] }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
+varpulis-runtime = { version = "0.11.0", path = "../varpulis-runtime", default-features = false, features = ["wasm"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = "0.2"

--- a/crates/varpulis-enrichment/Cargo.toml
+++ b/crates/varpulis-enrichment/Cargo.toml
@@ -9,8 +9,8 @@ documentation.workspace = true
 description = "External connector enrichment providers for VPL streams"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-connectors = { version = "0.10.0", path = "../varpulis-connectors" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-connectors = { version = "0.11.0", path = "../varpulis-connectors" }
 async-trait = "0.1"
 reqwest = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/varpulis-hamlet/Cargo.toml
+++ b/crates/varpulis-hamlet/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["streaming", "aggregation", "analytics", "real-time", "detection"]
 categories = ["science", "algorithms", "data-structures"]
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 rustc-hash = { workspace = true }
 smallvec = "1.13"
 tracing = { workspace = true }

--- a/crates/varpulis-lsp/Cargo.toml
+++ b/crates/varpulis-lsp/Cargo.toml
@@ -25,8 +25,8 @@ tower-lsp = "0.20"
 tokio = { workspace = true }
 
 # Varpulis crates
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 
 # Logging
 tracing = { workspace = true }

--- a/crates/varpulis-mcp/Cargo.toml
+++ b/crates/varpulis-mcp/Cargo.toml
@@ -26,9 +26,9 @@ anyhow = { workspace = true }
 reqwest = { workspace = true }
 schemars = "1"
 uuid = { version = "1", features = ["v4"] }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-runtime = { version = "0.10.0", path = "../varpulis-runtime", features = ["interactive"] }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-runtime = { version = "0.11.0", path = "../varpulis-runtime", features = ["interactive"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }

--- a/crates/varpulis-parser/Cargo.toml
+++ b/crates/varpulis-parser/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["parser-implementations", "development-tools"]
 build = "build.rs"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 logos = { workspace = true }
 thiserror = { workspace = true }
 miette = { workspace = true }

--- a/crates/varpulis-runtime/Cargo.toml
+++ b/crates/varpulis-runtime/Cargo.toml
@@ -11,14 +11,14 @@ keywords = ["stream-processing", "streaming", "runtime", "real-time", "detection
 categories = ["science", "development-tools", "data-structures"]
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
-varpulis-sase = { version = "0.10.0", path = "../varpulis-sase" }
-varpulis-zdd = { version = "0.10.0", path = "../varpulis-zdd" }
-varpulis-pst = { version = "0.10.0", path = "../varpulis-pst" }
-varpulis-hamlet = { version = "0.10.0", path = "../varpulis-hamlet" }
-varpulis-simd = { version = "0.10.0", path = "../varpulis-simd" }
-varpulis-dead-letter = { version = "0.10.0", path = "../varpulis-dead-letter" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
+varpulis-sase = { version = "0.11.0", path = "../varpulis-sase" }
+varpulis-zdd = { version = "0.11.0", path = "../varpulis-zdd" }
+varpulis-pst = { version = "0.11.0", path = "../varpulis-pst" }
+varpulis-hamlet = { version = "0.11.0", path = "../varpulis-hamlet" }
+varpulis-simd = { version = "0.11.0", path = "../varpulis-simd" }
+varpulis-dead-letter = { version = "0.11.0", path = "../varpulis-dead-letter" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
@@ -33,8 +33,8 @@ sha2 = { workspace = true }
 hex = { workspace = true }
 
 # async-runtime: dependencies that require a tokio async runtime (not WASM-compatible)
-varpulis-connectors = { version = "0.10.0", path = "../varpulis-connectors", optional = true }
-varpulis-enrichment = { version = "0.10.0", path = "../varpulis-enrichment", optional = true }
+varpulis-connectors = { version = "0.11.0", path = "../varpulis-connectors", optional = true }
+varpulis-enrichment = { version = "0.11.0", path = "../varpulis-enrichment", optional = true }
 tokio = { workspace = true, optional = true }
 reqwest = { workspace = true, optional = true }
 prometheus = { workspace = true, optional = true }
@@ -72,10 +72,10 @@ argon2 = { version = "0.5", optional = true }
 rmp-serde = { version = "1.3", optional = true }
 
 # WASM UDF support
-varpulis-wasm = { version = "0.10.0", path = "../varpulis-wasm", optional = true, features = ["smartmodule"] }
+varpulis-wasm = { version = "0.11.0", path = "../varpulis-wasm", optional = true, features = ["smartmodule"] }
 
 # Event generation for interactive mode
-varpulis-datagen = { version = "0.10.0", path = "../varpulis-datagen", optional = true }
+varpulis-datagen = { version = "0.11.0", path = "../varpulis-datagen", optional = true }
 
 [features]
 # `arrow` is in default so the release binary and web-ui preview mode get

--- a/crates/varpulis-sase/Cargo.toml
+++ b/crates/varpulis-sase/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["pattern-matching", "streaming", "detection", "nfa", "temporal"]
 categories = ["science", "algorithms", "data-structures"]
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-zdd = { version = "0.10.0", path = "../varpulis-zdd" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-zdd = { version = "0.11.0", path = "../varpulis-zdd" }
 chrono = { workspace = true }
 rustc-hash = { workspace = true }
 

--- a/crates/varpulis-simd/Cargo.toml
+++ b/crates/varpulis-simd/Cargo.toml
@@ -9,7 +9,7 @@ documentation.workspace = true
 description = "SIMD-optimized operations for high-performance event processing"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
 
 [lints]
 workspace = true

--- a/crates/varpulis-wasm/Cargo.toml
+++ b/crates/varpulis-wasm/Cargo.toml
@@ -12,8 +12,8 @@ description = "WASM bindings for VPL parser and validator"
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-parser = { version = "0.10.0", path = "../varpulis-parser" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-parser = { version = "0.11.0", path = "../varpulis-parser" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 wasm-bindgen = "0.2"

--- a/crates/varpulis/Cargo.toml
+++ b/crates/varpulis/Cargo.toml
@@ -19,5 +19,5 @@ name = "varpulis"
 path = "src/lib.rs"
 
 [dependencies]
-varpulis-core = { version = "0.10.0", path = "../varpulis-core" }
-varpulis-runtime = { version = "0.10.0", path = "../varpulis-runtime" }
+varpulis-core = { version = "0.11.0", path = "../varpulis-core" }
+varpulis-runtime = { version = "0.11.0", path = "../varpulis-runtime" }


### PR DESCRIPTION
## Release v0.11.0

Bumps the workspace `0.10.0 → 0.11.0` (all internal path-dep pins + `Cargo.lock`) and adds the CHANGELOG entry.

**This release** = the full 11-scope audit remediation + the distributed exactly-once ("Flink-parity") work. Every audit critical and the high/medium findings are closed; end-to-end exactly-once checkpointing is added; connector reliability and security hardening throughout.

### Highlights (full breakdown in `CHANGELOG.md`)
- **Added:** distributed exactly-once checkpointing (2PC barrier, Raft, NATS protocol, checkpoint migration); CDC over TLS (rustls, mTLS); dynamic `.to(topic)` on Redis; MQTT/Redis/Pulsar source auto-reconnect; Kafka decode→DLQ.
- **Changed:** dynamic `.to(topic)` on unsupported sinks now errors instead of silently misrouting; lazy SequenceMatch build; Rust 1.95 toolchain.
- **Fixed:** exactly-once correctness (C1/C3/C4); event-time watermarks (C2); cluster dead-worker detection + NATS control plane (C5/C6); bounded-memory OOM fixes; HttpSink non-2xx→Err; hot-reload routing; parser/evaluator safety; Kafka hot-path 88.5k→136k+ eps.
- **Security:** CDC slot-name SQLi validation; CDC TLS (was cleartext); credential redaction in `Debug` (kafka/redis/http/pulsar/config/profile); constant-time API-key compare; `/cluster/raft` auth; WebSocket cap; pipeline-graph DoS bounds.

Merging this, then tagging `v0.11.0` on `main`, triggers `release.yml` (PGO+BOLT binaries for 5 targets + GitHub release). crates.io publish (`publish.yml`) remains a separate manual `workflow_dispatch`.

> Note: v0.10.0 shipped without a changelog entry; this entry documents everything since v0.10.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)