### PR TITLE
fix(ci): install cross target for pinned toolchain + resilient release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,13 @@ jobs:
       - name: Build (native, non-PGO)
         if: ${{ !matrix.use_cross && matrix.target != 'x86_64-unknown-linux-gnu' }}
         run: |
+          # rust-toolchain.toml pins the toolchain cargo actually uses (1.95.0),
+          # and dtolnay/rust-toolchain@stable only adds the matrix target to
+          # `stable`. For a cross target that isn't the runner's host (e.g.
+          # x86_64-apple-darwin on the ARM macos-latest runner), the pinned
+          # toolchain is missing it → E0463 "can't find crate for `core`".
+          # Add it to the toolchain resolved by rust-toolchain.toml in this dir.
+          rustup target add ${{ matrix.target }}
           cargo build --release --target ${{ matrix.target }} -p varpulis-cli
           cargo build --release --target ${{ matrix.target }} -p varpulis-lsp
 
@@ -194,6 +201,10 @@ jobs:
   release:
     name: Create Release
     needs: [build, docker]
+    # Publish whatever built. A single failed target (or the docker job) must not
+    # skip the release entirely — otherwise a missing binary silently blocks the
+    # whole release, which is how v0.11.0 initially failed to publish.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -242,6 +253,9 @@ jobs:
           name: Varpulis v${{ steps.release_notes.outputs.version }}
           body_path: notes.md
           draft: false
+          # Don't fail the release if a target's binary is missing (e.g. one
+          # build target failed) — publish the assets that are present.
+          fail_on_unmatched_files: false
           prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}
           files: |
             artifacts/varpulis-linux-x86_64/varpulis-linux-x86_64


### PR DESCRIPTION
## Two release-workflow bugs surfaced by v0.11.0

**1. macOS Intel (`x86_64-apple-darwin`) failed** with `E0463: can't find crate for 'core'`. `macos-latest` is now Apple Silicon (ARM), so building the Intel target is a cross-compile needing the target installed — but `rust-toolchain.toml` pins **1.95.0** while `dtolnay/rust-toolchain@stable` only added the matrix target to `stable`. The toolchain cargo actually used (1.95.0, via the pin) was missing it. (aarch64/host targets worked — they're native to their runners.)
→ Add `rustup target add ${{ matrix.target }}` in-repo so it lands on the **pinned** toolchain.

**2. One failed target silently blocked the entire release.** The `release` job (`needs: [build, docker]`) had no `if:`, so a single failed matrix target skipped release creation — v0.11.0 tagged but published **nothing** (I published it manually with the 4 working targets).
→ Add `if: ${{ !cancelled() }}` + softprops `fail_on_unmatched_files: false` so it publishes whatever built.

### Effect
- Fix (1): the Intel-Mac binary builds again → next release is a clean 5/5.
- Fix (2): backstop — a future single-target failure degrades to a *partial* release (with the assets that built) instead of *no* release.

YAML validated. This is workflow-only; it takes effect on the next `v*` tag. (v0.11.0 itself is already published with 4/5 targets — Apple Silicon covered, only Intel Mac missing.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)