### PR TITLE
docs(connectors): fix broken intra-doc link failing the Documentation CI job

### DIFF
--- a/crates/varpulis-connectors/src/managed_registry.rs
+++ b/crates/varpulis-connectors/src/managed_registry.rs
@@ -91,7 +91,7 @@ impl ManagedConnectorRegistry {
 
     /// Fan the engine's cooperative source-pause flag out to every managed
     /// connector, so replayable sources stop pulling during a checkpoint
-    /// barrier's drain. Mirrors [`set_engine_offsets_registry`].
+    /// barrier's drain. Mirrors [`Self::set_engine_offsets_registry`].
     pub fn set_source_pause_handle(
         &mut self,
         handle: std::sync::Arc<std::sync::atomic::AtomicBool>,


### PR DESCRIPTION
The `Documentation` CI job (rustdoc under `-D warnings`) was red with:

```
error: unresolved link to `set_engine_offsets_registry`
  note: `-D rustdoc::broken-intra-doc-links` implied by `-D warnings`
error: could not document `varpulis-connectors`
```

`set_source_pause_handle`'s doc comment linked to its sibling method by **bare name**, which rustdoc can't resolve (methods need a type-qualified path). Qualified it as `[\`Self::set_engine_offsets_registry\`]` — keeps the working cross-reference.

Verified locally: `RUSTDOCFLAGS="-D warnings" cargo doc -p varpulis-connectors --no-deps` finishes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)